### PR TITLE
katsu sanity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ aws_secret_access_key = xxxxx
 Ingest files into S3-compatible stores one endpoint/bucket at a time.
 
 ```bash
-python s3_ingest.py --sample <sample>|--samplefile <samplefile> --dataset <dataset> --endpoint <S3 endpoint> --bucket <S3 bucket> --awsfile <aws credentials>
+python s3_ingest.py --sample <sample>|--samplefile <samplefile> --endpoint <S3 endpoint> --bucket <S3 bucket> --awsfile <aws credentials>
 ```
 
 ### Ingest into Htsget
@@ -68,7 +68,26 @@ python htsget_ingest.py --sample <sample>|--samplefile <samplefile> --dataset <d
 ### Ingest into candig-server
 Candig-server performs variant search for CanDIG. It needs its data ingested from the local command line; there is no REST API for ingest.
 
-* You'll need to know the name of the referenceset on your candig-server instance. Make sure that the referenceset needed for your variant files is already created on your candig-server instance (see https://candig-server.readthedocs.io/en/v1.6.0/datarepo.html#add-referenceset for details).
+* You'll need to know the name of the referenceset on your candig-server instance. Make sure that the referenceset needed for your variant files is already created on your candig-server instance.
+
+<blockquote><details><summary>How do I add a referenceset?</summary>
+See https://candig-server.readthedocs.io/en/v1.6.0/datarepo.html#add-referenceset for detailed instructions, but a quick version:
+
+From inside the candig-server instance, download the reference files:
+```bash
+curl https://daisietestbucket1.s3.amazonaws.com/hs37d5.fa.gz > /hs37d5.fa.gz
+curl https://daisietestbucket1.s3.amazonaws.com/hs37d5.fa.gz.gzi > /hs37d5.fa.gz.gzi
+```
+Then add the reference set:
+```bash
+candig_repo add-referenceset <your db> /hs37d5.fa.gz \
+		--description "NCBI37 assembly of the human genome" \
+		--species '{"termId": "NCBI:9606", "term": "Homo sapiens"}' \
+		--name hs37d5 \
+		--sourceUri http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz
+```
+</details></blockquote>
+
 * You'll need a csv input file containing the mapping between the patient_ids and the variant_ids and the names of the columns corresponding to each. 
 * The variant files need to be mounted on a path that is accessible to candig-server.
 
@@ -85,6 +104,8 @@ docker cp temp/candigv1_data.json candigv2_candig-server_1:/app/candig-server/
 docker cp temp/candigv1_ingest.sh candigv2_candig-server_1:/app/candig-server/
 docker exec candigv2_candig-server_1 /app/candig-server/candigv1_ingest.sh
 ``` 
+
+Don't forget that you need to restart the candig-server instance to pick up the changes!
 
 ## Ingest clinical data
 ### Transform raw data into mcodepacket format
@@ -120,8 +141,8 @@ Then run the ingest tool:
 python katsu_ingest.py --dataset $(DATASET) --input /input.json
 ```
 
-As a quick sanity check, there is a simple little `katsu_status.py` script that will tell you how many 
-projects, datasets, and individuals are in the katsu at `$CANDIG_URL`. 
+As a quick sanity check, there is a simple little `katsu_status.py` script that will tell you how many
+projects, datasets, and individuals are in the katsu at `$CANDIG_URL`.
 
 After installation, you should be able to access the synthetic dataset:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ aws_secret_access_key = xxxxx
 Ingest files into S3-compatible stores one endpoint/bucket at a time.
 
 ```bash
-python s3_ingest.py --sample <sample>|--samplefile <samplefile> --endpoint <S3 endpoint> --bucket <S3 bucket> --awsfile <aws credentials>
+python s3_ingest.py --sample <sample>|--samplefile <samplefile> --dataset <dataset> --endpoint <S3 endpoint> --bucket <S3 bucket> --awsfile <aws credentials>
 ```
 
 ### Ingest into Htsget
@@ -68,26 +68,7 @@ python htsget_ingest.py --sample <sample>|--samplefile <samplefile> --dataset <d
 ### Ingest into candig-server
 Candig-server performs variant search for CanDIG. It needs its data ingested from the local command line; there is no REST API for ingest.
 
-* You'll need to know the name of the referenceset on your candig-server instance. Make sure that the referenceset needed for your variant files is already created on your candig-server instance.
-
-<blockquote><details><summary>How do I add a referenceset?</summary>
-See https://candig-server.readthedocs.io/en/v1.6.0/datarepo.html#add-referenceset for detailed instructions, but a quick version:
-
-From inside the candig-server instance, download the reference files:
-```bash
-curl https://daisietestbucket1.s3.amazonaws.com/hs37d5.fa.gz > /hs37d5.fa.gz
-curl https://daisietestbucket1.s3.amazonaws.com/hs37d5.fa.gz.gzi > /hs37d5.fa.gz.gzi
-```
-Then add the reference set:
-```bash
-candig_repo add-referenceset <your db> /hs37d5.fa.gz \
-		--description "NCBI37 assembly of the human genome" \
-		--species '{"termId": "NCBI:9606", "term": "Homo sapiens"}' \
-		--name hs37d5 \
-		--sourceUri http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz
-```
-</details></blockquote>
-
+* You'll need to know the name of the referenceset on your candig-server instance. Make sure that the referenceset needed for your variant files is already created on your candig-server instance (see https://candig-server.readthedocs.io/en/v1.6.0/datarepo.html#add-referenceset for details).
 * You'll need a csv input file containing the mapping between the patient_ids and the variant_ids and the names of the columns corresponding to each. 
 * The variant files need to be mounted on a path that is accessible to candig-server.
 
@@ -104,8 +85,6 @@ docker cp temp/candigv1_data.json candigv2_candig-server_1:/app/candig-server/
 docker cp temp/candigv1_ingest.sh candigv2_candig-server_1:/app/candig-server/
 docker exec candigv2_candig-server_1 /app/candig-server/candigv1_ingest.sh
 ``` 
-
-Don't forget that you need to restart the candig-server instance to pick up the changes!
 
 ## Ingest clinical data
 ### Transform raw data into mcodepacket format
@@ -141,6 +120,8 @@ Then run the ingest tool:
 python katsu_ingest.py --dataset $(DATASET) --input /input.json
 ```
 
+As a quick sanity check, there is a simple little `katsu_status.py` script that will tell you how many 
+projects, datasets, and individuals are in the katsu at `$CANDIG_URL`. 
 
 After installation, you should be able to access the synthetic dataset:
 

--- a/katsu_clean.py
+++ b/katsu_clean.py
@@ -10,6 +10,8 @@ TOKEN = auth.get_site_admin_token()
 def get_uuids(katsu_server_url, dataset_title):
     headers = {"Authorization": f"Bearer {TOKEN}"}
     results = requests.get(katsu_server_url + "/api/datasets", headers=headers)
+    print(headers)
+    print(results.json())
     if "results" in results.json():
         for r in results.json()["results"]:
             if r["title"] == dataset_title:
@@ -32,6 +34,7 @@ def delete_data(katsu_server_url, data_file, data_type):
     with open(data_file) as f:
         packets = json.load(f)
         for p in packets:
+            print(f"deleting {data_type} {p['id']}")
             r = requests.delete(katsu_server_url + f"/api/{data_type}s/{p['id']}", headers=headers)
 
 
@@ -47,13 +50,16 @@ def main():
     katsu_server_url = args.server_url
 
     katsu_server_url = os.environ.get("CANDIG_URL")
+    print(katsu_server_url)
     if katsu_server_url is None:
         raise Exception("CANDIG_URL environment variable is not set")
     else:
         katsu_server_url = katsu_server_url + "/katsu"
 
     dataset_uuid, project_uuid = get_uuids(katsu_server_url, dataset_title)
+    print(f"dataset {dataset_uuid}, project {project_uuid}")
     delete_data(katsu_server_url, args.data_file, "mcodepacket")
+    delete_data(katsu_server_url, args.data_file, "individual")
     delete_dataset(katsu_server_url, dataset_uuid)
     delete_project(katsu_server_url, project_uuid)
     

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -40,11 +40,12 @@ def create_project(katsu_server_url, project_title):
         return project_uuid
     elif r.status_code == 400:
         results = requests.get(katsu_server_url + "/api/projects", headers=headers)
-        print(results.json())
         for r in results.json()["results"]:
             if r["title"] == project_title:
+                print(f"Project {project_title} already exists")
                 return r["identifier"]
     else:
+        print(f"Problem creating project {project_title}")
         print(r.json())
         sys.exit()
 
@@ -82,6 +83,7 @@ def create_dataset(katsu_server_url, project_uuid, dataset_title):
         results = requests.get(katsu_server_url + "/api/datasets", headers=headers)
         for r in results.json()["results"]:
             if r["title"] == dataset_title:
+                print(f"Dataset {dataset_title} already exists")
                 return r["identifier"]
     else:
         print(r2.json())
@@ -153,6 +155,7 @@ def ingest_data(katsu_server_url, table_id, data_file, data_type):
 
     if r5.status_code == 200 or r5.status_code == 201 or r5.status_code == 204:
         print("{} Data have been ingested from source at {}".format(data_type, data_file))
+        print(f"Status code {r5.status_code}")
     elif r5.status_code == 400:
         print(r5.text)
         sys.exit()
@@ -176,7 +179,7 @@ def main():
 
     args = parser.parse_args()
     dataset_title = args.dataset
-    project_title = dataset_title
+    project_title = dataset_title 
     table_name = dataset_title
     data_file = args.input
     data_type = "mcodepacket"

--- a/katsu_stats.py
+++ b/katsu_stats.py
@@ -1,0 +1,52 @@
+import sys
+import argparse
+import json
+import requests
+import auth
+import os
+
+"""
+Gives some stats about what is in katsu
+
+Lists projects, datasets, individuals
+"""
+
+TOKEN = auth.get_site_admin_token()
+
+def list_data_type(katsu_server_url, data_type):
+    """
+    Lists the current datasets.
+
+    """
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+
+    results = requests.get(katsu_server_url + "/api/" + data_type, headers=headers)
+    count = len(results.json()["results"])
+    print(f"{data_type} (n={count}):")
+    for r in results.json()["results"]:
+        try:    
+            # projects and datasets
+            print(f"\t{r['title']}, uuid {r['identifier']}")
+        except KeyError:
+            # individuals
+            print(f"\t{r['id']}")
+            
+
+
+def main():
+
+    katsu_server_url = os.environ.get("CANDIG_URL")
+    if katsu_server_url is None:
+        raise Exception("CANDIG_URL environment variable is not set")
+    else:
+        katsu_server_url = katsu_server_url + "/katsu"
+
+    data_type = "projects"
+    list_data_type(katsu_server_url,data_type)
+    data_type = "datasets"
+    list_data_type(katsu_server_url,data_type)
+    data_type = "individuals"
+    list_data_type(katsu_server_url,data_type)
+
+if __name__ == "__main__":
+    main()

--- a/katsu_stats.py
+++ b/katsu_stats.py
@@ -16,7 +16,7 @@ TOKEN = auth.get_site_admin_token()
 def list_data_type(katsu_server_url, data_type):
     """
     Lists the current datasets.
-
+    Does not currently handle pagination for individuals, so you only get the first 25.
     """
     headers = {"Authorization": f"Bearer {TOKEN}"}
 


### PR DESCRIPTION
* Adds some more output to the `katsu_ingest.py`
* add a `katsu_stats .py` script that outputs the number of projects, datasets, individuals (noting that the individuals part doesn't handle pagination in its current incarnation)
* also deletes individuals with `katsu_clean.py`