### PR TITLE
DIG-931: update to match https://github.com/CanDIG/candigv2-authx/pull/3

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -49,8 +49,10 @@ def parse_aws_credential(awsfile):
     return {"access": access, "secret": secret}
 
 
-def store_aws_credential(endpoint=None, bucket=None, access=None, secret=None):
-    result, status_code = authx.auth.store_aws_credential(endpoint=endpoint, bucket=bucket, access=access, secret=secret)
+def store_aws_credential(token=None, endpoint=None, url=None, bucket=None, access=None, secret=None):
+    if token is None:
+        token = get_site_admin_token()
+    result, status_code = authx.auth.store_aws_credential(token=token, endpoint=endpoint, s3_url=url, bucket=bucket, access=access, secret=secret)
     return status_code == 200
 
 


### PR DESCRIPTION
After https://github.com/CanDIG/candigv2-authx/pull/3, store_aws_credentials takes in a token as an argument, so we should pass in the site_admin_token to that.