### PR TITLE
DIG-1143: Sample DRS objects on htsget ingest

### DIFF
--- a/htsget_file_ingest.py
+++ b/htsget_file_ingest.py
@@ -4,13 +4,8 @@ import auth
 import os
 import re
 import json
-from urllib.parse import urlparse
-import time
+from htsget_methods import post_to_dataset, get_dataset_objects, post_objects
 
-CANDIG_URL = os.getenv("CANDIG_URL", "")
-HTSGET_URL = CANDIG_URL + "/genomics"
-VAULT_URL = CANDIG_URL + "/vault"
-HOSTNAME = CANDIG_URL.replace(f"{urlparse(CANDIG_URL).scheme}://","")
 
 def collect_samples_for_genomic_id(genomic_id, file):
     type_parse = re.match(r"(.+)\.(vcf|bam|cram|sam|bcf)(\.gz)*", file)
@@ -24,134 +19,21 @@ def collect_samples_for_genomic_id(genomic_id, file):
         elif type_parse.group(2) == 'cram':
             type = 'read'
             index = f"{file}.crai"
-        return {
+        return [{
                 "id": genomic_id,
-                "file": file,
-                "index": index,
-                "type": type
-            }
-
-
-def post_objects(genomic_id, samples_to_create, token, ref_genome="hg38", force=False):
-    headers = {"Authorization": f"Bearer {token}"}
-
-    for s in samples_to_create:
-        filename = os.path.basename(s['file'])
-        filepath = os.path.abspath(s['file'])
-        indexname = os.path.basename(s['index'])
-        indexpath = os.path.abspath(s['index'])
-        print(f"working on {s['id']}")
-        url = f"{HTSGET_URL}/ga4gh/drs/v1/objects"
-        # master object:
-        obj = {
-            "contents": [
-              {
-                "drs_uri": [
-                  f"drs://{HOSTNAME}/{filename}"
-                ],
-                "name": filename,
-                "id": s["type"]
-              },
-              {
-                "drs_uri": [
-                  f"drs://{HOSTNAME}/{indexname}"
-                ],
-                "name": indexname,
-                "id": "index"
-              }
-            ],
-            "id": s['id'],
-            "name": s['id'],
-            "self_uri": f"drs://{HOSTNAME}/{s['id']}",
-            "version": "v1"
-        }
-        response = requests.post(url, json=obj, headers=headers)
-        if response.status_code > 200:
-            print(response.text)
-
-        # file object:
-        obj = {
-            "access_methods": [
-                {
-                    "access_url": {
-                        "headers": [],
-                        "url": f"file://{filepath}"
-                    },
-                    "type": "file"
-                }
-            ],
-            "id": filename,
-            "name": filename,
-            "self_uri": f"drs://{HOSTNAME}/{filename}",
-            "version": "v1"
-        }
-        response = requests.post(url, json=obj, headers=headers)
-        if response.status_code > 200:
-            print(response.text)
-
-        # index object:
-        obj = {
-            "access_methods": [
-                {
-                    "access_url": {
-                        "headers": [],
-                        "url": f"file://{indexpath}"
-                    },
-                    "type": "file"
-                }
-            ],
-            "id": indexname,
-            "name": indexname,
-            "self_uri": f"drs://{HOSTNAME}/{indexname}",
-            "version": "v1"
-        }
-        response = requests.post(url, json=obj, headers=headers)
-        if response.status_code > 200:
-            print(response.text)
-        
-        # index for search:
-        url = f"{HTSGET_URL}/htsget/v1/variants/{s['id']}/index"
-        response = requests.get(url, params={"genome": ref_genome, "force": force, "genomic_id": genomic_id}, headers=headers)
-        if response.status_code > 200:
-            print(response.text)
-    return response
-
-
-def post_to_dataset(sample_ids, dataset, token):
-    headers = {"Authorization": f"Bearer {token}"}
-    drsobjects = map(lambda s : f"drs://{HOSTNAME}/{s}", sample_ids)
-    obj = {
-        "id": dataset,
-        "drsobjects": list(drsobjects)
-    }
-    url = f"{HTSGET_URL}/ga4gh/drs/v1/datasets"
-    response = requests.post(url, json=obj, headers=headers)
-
-
-def get_dataset_objects(dataset, token):
-    headers = {"Authorization": f"Bearer {token}"}
-    url = f"{HTSGET_URL}/ga4gh/drs/v1/datasets/{dataset}"
-    response = requests.get(url, headers=headers)
-    if response.status_code == 200:
-        objects = []
-        drs_objs = response.json()["drsobjects"]
-        while len(drs_objs) > 0:
-            obj = drs_objs.pop(0)
-            url = f"{HTSGET_URL}/ga4gh/drs/v1/objects{urlparse(obj).path}"
-            response = requests.get(url, headers=headers)
-            if response.status_code == 200:
-                objects.append(response.json())
-                if "contents" in response.json():
-                    for item in response.json()["contents"]:
-                        drs_objs.insert(0, item["drs_uri"][0])
-        return objects
-    return response.json()
+                "file": os.path.basename(file),
+                "index": os.path.basename(index),
+                "type": type,
+                "file_access": f"file://{os.path.abspath(file)}",
+                "index_access": f"file://{os.path.abspath(index)}"
+            }]
 
 
 def main():
     parser = argparse.ArgumentParser(description="A script that ingests a sample vcf and its index into htsget.")
 
-    parser.add_argument("--sample", help="genomic sample id")
+    parser.add_argument("--genomic_id", help="genomic sample id")
+    parser.add_argument("--clinical_id", help="clinical sample registration id", required=False)
     parser.add_argument("--file", help="path to main file")
     parser.add_argument("--dataset", help="dataset name")
     parser.add_argument("--reference", help="optional: reference genome, either hg37 or hg38", required=False, default="hg38")
@@ -159,15 +41,14 @@ def main():
 
     args = parser.parse_args()
 
-    if CANDIG_URL == "":
+    if os.getenv("CANDIG_URL") == "":
         raise Exception("CANDIG_URL environment variable is not set")
 
     token = auth.get_site_admin_token()
-    
-    token = auth.get_site_admin_token()
-    objects_to_create = collect_samples_for_genomic_id(args.sample, args.file)
-    post_objects(args.sample, [objects_to_create], token, ref_genome=args.reference, force=args.indexing)
-    post_to_dataset([args.sample], args.dataset, token)
+
+    objects_to_create = collect_samples_for_genomic_id(args.genomic_id, args.file)
+    post_objects(args.genomic_id, objects_to_create, token, clinical_id=args.clinical_id, ref_genome=args.reference, force=args.indexing)
+    post_to_dataset([args.genomic_id], args.dataset, token)
     response = get_dataset_objects(args.dataset, token)
     print(json.dumps(response, indent=4))
 

--- a/htsget_methods.py
+++ b/htsget_methods.py
@@ -75,6 +75,7 @@ def post_objects(genomic_id, genomic_objs_to_create, token, clinical_id=None, re
         response = requests.post(url, json=obj, headers=headers)
         if response.status_code > 200:
             print(response.text)
+        genomic_drs_obj = response.json()['self_uri']
 
         # file object:
         access_method = {}
@@ -125,6 +126,27 @@ def post_objects(genomic_id, genomic_objs_to_create, token, clinical_id=None, re
         response = requests.post(url, json=obj, headers=headers)
         if response.status_code > 200:
             print(response.text)
+
+        # add this genomic_id to the sample drs object, if available
+        genomic_content = {
+            "drs_uri": [
+                genomic_drs_obj
+            ],
+            "name": genomic_id,
+            "id": "genomic"
+        }
+
+        obj = {
+            "id": clinical_id,
+            "contents": [genomic_content],
+            "version": "v1"
+        }
+
+        response = requests.get(f"{url}/{clinical_id}", headers=headers)
+        if response.status_code == 200:
+            obj = response.json()
+            obj['contents'].append(genomic_content)
+        response = requests.post(url, json=obj, headers=headers)
 
         # index for search:
         url = f"{HTSGET_URL}/htsget/v1/variants/{s['id']}/index"

--- a/htsget_methods.py
+++ b/htsget_methods.py
@@ -1,0 +1,133 @@
+import requests
+import auth
+import os
+import re
+from urllib.parse import urlparse
+
+CANDIG_URL = os.getenv("CANDIG_URL", "")
+HTSGET_URL = CANDIG_URL + "/genomics"
+VAULT_URL = CANDIG_URL + "/vault"
+HOSTNAME = HTSGET_URL.replace(f"{urlparse(CANDIG_URL).scheme}://","")
+
+def post_to_dataset(sample_ids, dataset, token):
+    headers = {"Authorization": f"Bearer {token}"}
+    drsobjects = map(lambda s : f"drs://{HOSTNAME}/{s}", sample_ids)
+    obj = {
+        "id": dataset,
+        "drsobjects": list(drsobjects)
+    }
+    print(obj)
+    url = f"{HTSGET_URL}/ga4gh/drs/v1/datasets"
+    response = requests.post(url, json=obj, headers=headers)
+    if response.status_code > 300:
+        print(response.text)
+
+
+def get_dataset_objects(dataset, token):
+    headers = {"Authorization": f"Bearer {token}"}
+    url = f"{HTSGET_URL}/ga4gh/drs/v1/datasets/{dataset}"
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        objects = []
+        drs_objs = response.json()["drsobjects"]
+        while len(drs_objs) > 0:
+            obj = drs_objs.pop(0)
+            drs_obj_match = re.match(r"^(.+)\/(.+)$", obj)
+            url = f'{HTSGET_URL}/ga4gh/drs/v1/objects/{drs_obj_match.group(2)}'
+            response = requests.get(url, headers=headers)
+            if response.status_code == 200:
+                objects.append(response.json())
+                if "contents" in response.json():
+                    for item in response.json()["contents"]:
+                        drs_objs.insert(0, item["drs_uri"][0])
+        return objects
+    return response.json()
+
+
+def post_objects(genomic_id, genomic_objs_to_create, token, clinical_id=None, ref_genome="hg38", force=False):
+    headers = {"Authorization": f"Bearer {token}"}
+
+    for s in genomic_objs_to_create:
+        print(f"working on {s['id']}")
+        url = f"{HTSGET_URL}/ga4gh/drs/v1/objects"
+        # master object:
+        obj = {
+            "contents": [
+              {
+                "drs_uri": [
+                  f"drs://{HOSTNAME}/{s['file']}"
+                ],
+                "name": s['file'],
+                "id": s["type"]
+              },
+              {
+                "drs_uri": [
+                  f"drs://{HOSTNAME}/{s['index']}"
+                ],
+                "name": s['index'],
+                "id": "index"
+              }
+            ],
+            "id": s['id'],
+            "name": s['id'],
+            "version": "v1"
+        }
+        response = requests.post(url, json=obj, headers=headers)
+        if response.status_code > 200:
+            print(response.text)
+
+        # file object:
+        access_method = {}
+        if s['file_access'].startswith("file://"):
+            access_method["access_url"] = {
+                "headers": [],
+                "url": s['file_access']
+            }
+            access_method["type"] = "file"
+
+        else:
+            access_method["access_id"] = s['file_access']
+            access_method["type"] = "s3"
+
+        obj = {
+            "access_methods": [
+                access_method
+            ],
+            "id": s["file"],
+            "name": s["file"],
+            "version": "v1"
+        }
+        response = requests.post(url, json=obj, headers=headers)
+        if response.status_code > 200:
+            print(response.text)
+
+        # index object:
+        access_method = {}
+        if s['index_access'].startswith("file://"):
+            access_method["access_url"] = {
+                "headers": [],
+                "url": s['index_access']
+            }
+            access_method["type"] = "file"
+
+        else:
+            access_method["access_id"] = s['index_access']
+            access_method["type"] = "s3"
+
+        obj = {
+            "access_methods": [
+                access_method
+            ],
+            "id": s["index"],
+            "name": s["index"],
+            "version": "v1"
+        }
+        response = requests.post(url, json=obj, headers=headers)
+        if response.status_code > 200:
+            print(response.text)
+
+        # index for search:
+        url = f"{HTSGET_URL}/htsget/v1/variants/{s['id']}/index"
+        response = requests.get(url, params={"genome": ref_genome, "force": force, "genomic_id": genomic_id}, headers=headers)
+        if response.status_code > 200:
+            print(response.text)


### PR DESCRIPTION
```
source ../CanDIGv2/env.sh
python htsget_s3_ingest.py --samplefile temp/samples.txt --endpoint $MINIO_URL --bucket testhtsget --dataset SYNTHETIC-1 --access $MINIO_ACCESS_KEY --secret $MINIO_SECRET_KEY --clinical_id SAMPLE_REGISTRATION_1
python htsget_file_ingest.py --genomic_id HG02102 --clinical_id SAMPLE_REGISTRATION_2 --file /app/htsget_server/data/files/HG02102.vcf.gz --dataset SYNTHETIC-2
```

You should be able to see the sample drs objects with:
```
curl "http://candig.docker.internal:5080/genomics/ga4gh/drs/v1/objects/SAMPLE_REGISTRATION_2" \
     -H 'Authorization: Bearer <token>'
curl "http://candig.docker.internal:5080/genomics/ga4gh/drs/v1/objects/SAMPLE_REGISTRATION_1" \
     -H 'Authorization: Bearer <token>'
```
