### PR TITLE
New API + schema for htsget/katsu ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,39 +80,44 @@ python s3_ingest.py --sample <sample>|--samplefile <samplefile> --endpoint <S3 e
 
 </details></blockquote>
 
+## Add S3 credentials to vault
+This can be done through the /add-s3-credential API endpoint. Simply provide the endpoint, bucket name, access key and secret key as the JSON body:
+{
+	"endpoint": "candig.docker.internal:9000",
+	"bucket": "mohccndata",
+	"access_key": "admin",
+	"secret_key": "BsjbFTCQ8TpKVRj9euQEsQ"
+}
+Your bucket will now be usable for htsget ingest.
+
 ### Store locally in htsget
-If necessary, genomic samples can be loaded directly from the htsget container's internal storage. Simply `docker cp` the sample files somewhere into the container and proceed below with the instructions for local ingest.
+If necessary, genomic samples can be loaded directly from the htsget container's internal storage. Simply `docker cp` the sample files somewhere into the container and prefix your access_method with file:// instead of s3:// (see below).
 
 ### Ingest into Htsget
 
-Genomic samples should be specified in a JSON list of dictionaries, providing their genomic ID, clinical IDs and optionally filenames.
-The respective keys for these attributes are genomic_id, clinical_id, and files; if filenames are specified, the files key
-should be another dictionary with the keys "index" and "sample", which specify the genomic index file and variation file respectively.
-For example:
-
+Genomic samples should be specified in a JSON dictionary:
 ```json
-[
-  {"genomic_id": "HG00096", "clinical_id": "DONOR_1", "files": null}, 
-  {"genomic_id": "HG00097", "clinical_id": "DONOR_2", "files": {"sample": "HG97_SAMPLE.vcf.gz", "index": "HG97_SAMPLE.vcf.gz.tbi"}}
-  {"genomic_id": "HG00099", "clinical_id": "DONOR_3", "files": null}
-]
+{
+	"access_method": "s3://candig.docker.internal:9000/dir",
+	"genomic_id": "HG00096.vcf.gz",
+	"index": "tbi",
+  "samples": [
+    {
+      "sample_name_in_file": "TUMOR",
+      "sample_registration_id": "SAMPLE_REGISTRATION_1"
+    }
+  ]
+}
 ```
-If files are stored in an S3 Bucket, the location of the files should be provided using the prefix argument in htsget_ingest, and only filenames should be given in the JSON.
-For local ingest, absolute paths within the container should be provided for filenames.
-
-If filenames are not provided, the ingest will search for any variation/index files in the container prefixed with the genomic_id.
-For local ingest, filenames must be specified.
+“genomic_id” is the filename of the variation file (e.g. HG00096.vcf.gz, HG00096.bam). Access methods can either be of the format s3://[endpoint]/[bucket name] or file://[directory relative to root on htsget container]. sample_registration_id(s) are the (mandatory) links to clinical sample_registrations.
+"index" is the file extension of the index file for the variation; for instance, "tbi" or "crai".
+If an S3 bucket access method is provided, assuming you have properly added the S3 credentials to vault (see above), the service will scan the S3 bucket to ensure the relevant files are present.
+This will not occur for files local/mounted to htsget, so ensure they are present beforehand.
 
 To ingest using an S3 container, once the files have been added, you can run the htsget_ingest.py script:
 ```bash
-python htsget_ingest.py --samplefile [JSON-formatted sample list as specified] --dataset <dataset>  --awsfile <aws credentials> --endpoint <S3 endpoint> --bucket <S3 bucket> --prefix <optional, prefix for files in S3 bucket> --reference <reference genome, either hg37 or hg38> --indexing <optional, force re-index>
+python htsget_ingest.py --samplefile [JSON-formatted sample data as specified] --dataset <dataset> --reference <reference genome, either hg37 or hg38> --indexing <optional, force re-index>
 ```
-
-To ingest from the htsget container, you can use the -local flag:
-```bash
-python htsget_ingest.py -local --samplefile [JSON-formatted sample list] --dataset <dataset>  --reference <reference genome, either hg37 or hg38> --indexing <optional, force re-index>
-```
-
 
 ## Ingest clinical data
 
@@ -160,22 +165,10 @@ Also, Note that VAULT_URL's host is often set as 0.0.0.0, which the container ma
 if so, set it to candig.docker.internal:8200 (or whatever your vault port is).
 
 
-This will start a Docker container with a REST API for the ingest at localhost:1235. You can ingest a DonorWithClincalData object by POSTing JSON to localhost:1236/ingest/clinical_donors (an example is given in single_ingest.json, or you can simply copy the "results" key from a Katsu DonorWithClinicalData authorized query). 
-Genomic data can be ingested from an S3 bucket at the /ingest_genomic endpoint, with the following JSON format:
-```json
-{
-    "dataset": "[dataset name]",
-    "endpoint": "[S3 URL]",
-    "bucket": "[S3 bucket name]",
-    "access": "[S3 bucket access username]",
-    "secret": "[S3 bucket access password]",
-    "samples": [JSON formatted samples, see command line instructions],
-    "prefix": "[S3 prefix, optional]",
-    "reference": "[Reference genome, either hg37 or hg38, optional]",
-    "indexing": "[Force reindexing (true/false), optional]",
-    "local": true/false (whether to ingest from htsget local storage instead of s3)
-}
-```
+This will start a Docker container with a REST API for the ingest at localhost:1235. You can ingest a DonorWithClincalData object by POSTing JSON to localhost:1236/ingest/clinical_donors (an example is given in single_ingest.json).
+
+Genomic data can be ingested at the /ingest/moh_variants/{program ID} endpoint, where program_id is a cohort ID to add the variant to. This takes the same JSON body as specified in the htsget ingest section above.
+
 Make sure you include Authorization headers as well. Both endpoints take refresh tokens, as a header with the key `{"Authorization": "Bearer [refresh token]"}`.
 
 (Note: on the CanDIGv2 repo, the service runs on port 1235; it is run as 1236 locally in these instructions to ensure there is no

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Also, Note that VAULT_URL's host is often set as 0.0.0.0, which the container ma
 if so, set it to candig.docker.internal:8200 (or whatever your vault port is).
 
 
-This will start a Docker container with a REST API for the ingest at localhost:1235. You can ingest a DonorWithClincalData object by POSTing JSON to localhost:1236/ingest_donor (an example is given in single_ingest.json, or you can simply copy the "results" key from a Katsu DonorWithClinicalData authorized query). 
+This will start a Docker container with a REST API for the ingest at localhost:1235. You can ingest a DonorWithClincalData object by POSTing JSON to localhost:1236/ingest/clinical_donors (an example is given in single_ingest.json, or you can simply copy the "results" key from a Katsu DonorWithClinicalData authorized query). 
 Genomic data can be ingested from an S3 bucket at the /ingest_genomic endpoint, with the following JSON format:
 ```json
 {

--- a/app.py
+++ b/app.py
@@ -11,7 +11,6 @@ def create_app():
     connexionApp = FlaskApp(__name__, specification_dir='./')
     connexionApp.add_api('ingest_openapi.yaml', pythonic_params=True, strict_validation=True)
     app = connexionApp.app
-    app.register_blueprint(katsu_ingest.ingest_blueprint)
     app.register_blueprint(htsget_ingest.ingest_blueprint)
     #app.add_url_rule('/', 'root', root)
     return app

--- a/app.py
+++ b/app.py
@@ -11,8 +11,7 @@ def create_app():
     connexionApp = FlaskApp(__name__, specification_dir='./')
     connexionApp.add_api('ingest_openapi.yaml', pythonic_params=True, strict_validation=True)
     app = connexionApp.app
-    app.register_blueprint(htsget_ingest.ingest_blueprint)
-    #app.add_url_rule('/', 'root', root)
+    app.add_url_rule('/', 'root', root)
     return app
 
 if __name__ == '__main__':

--- a/auth.py
+++ b/auth.py
@@ -100,13 +100,11 @@ def parse_aws_credential(awsfile):
     return {"access": access, "secret": secret}
 
 
-def store_aws_credential(token=None, client=None):
+def store_aws_credential(endpoint, bucket, access, secret, token=None):
     if token is None:
         token = get_site_admin_token()
-    if client is None:
-        return {"error": "No client provided"}, 500
-    print(client)
-    return authx.auth.store_aws_credential(token=token, endpoint=client["endpoint"], bucket=client["bucket"], access=client["access"], secret=client["secret"])
+    return authx.auth.store_aws_credential(token=token, endpoint=endpoint, bucket=bucket,
+                                           access=access, secret=secret)
 
 def is_authed(request: requests.Request):
     if 'Authorization' not in request.headers:

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -4,279 +4,91 @@ import auth
 import os
 import re
 import json
-from htsget_methods import post_to_dataset, get_dataset_objects, post_objects
+from htsget_methods import post_to_dataset, post_object
 from ingest_result import IngestPermissionsException, IngestServerException, IngestUserException, IngestResult
-import traceback
 
 
-from flask import Blueprint, request
+from flask import Blueprint
 
 ingest_blueprint = Blueprint("ingest_genomic", __name__)
 
-def collect_samples_for_genomic_id(genomic_id, client, genomic_files={}, prefix=""):
+def create_s3_sample(genomic_id: str, index: str, client):
     # If genomic_files is provided, it means the filenames do not correspond to the genomic_id names in the bucket
     # And have been provided manually.
-    files = []
-    samples = []
-    if genomic_files:
-        sample = genomic_files["sample"]
-        index = genomic_files["index"]
-        index_pattern = re.compile(f"({prefix}(.+?))(\.tbi|\.bai|\.crai|\.csi)$")
-        index_parse = index_pattern.match(index)
-        type = 'read'
-        if index_parse.group(3) == '.tbi':
-            type = 'variant'
-        samples.append(
-            {
-                "id": genomic_id,
-                "file": sample,
-                "index": index,
-                "type": type,
-                "file_access": f"{client['endpoint']}/{client['bucket']}/{prefix}{sample}",
-                "index_access": f"{client['endpoint']}/{client['bucket']}/{prefix}{index}"
-            }
-        )
-    else:
-        # first, find all files that are related to this sample at the endpoint:
-        files_iterator = client['client'].list_objects(client["bucket"], prefix=prefix+genomic_id)
-        for f in files_iterator:
-            files.append(f.object_name)
-    while len(files) > 0:
-        f = files.pop(0)
-        index_pattern = re.compile(f"({prefix}(.+?))(\.tbi|\.bai|\.crai|\.csi)$")
-        index_parse = index_pattern.match(f)
-        if index_parse is not None: # this is a file we're interested in
-            if index_parse.group(3) is not None and index_parse.group(3) != "":
-                index = index_parse.group(2) + index_parse.group(3)
-                # f is an index file, so it should have a corresponding file
-                file = index_parse.group(2)
-                if index_parse.group(1) in files:
-                    files.remove(index_parse.group(1))
-                type = 'read'
-                if index_parse.group(3) == '.tbi':
-                    type = 'variant'
-                samples.append(
-                    {
-                        "id": genomic_id,
-                        "file": file,
-                        "index": index,
-                        "type": type,
-                        "file_access": f"{client['endpoint']}/{client['bucket']}/{prefix}{file}",
-                        "index_access": f"{client['endpoint']}/{client['bucket']}/{prefix}{index}"
-                    }
-                )
-    return samples
-
-def collect_samples_for_genomic_id_local(sample):
-    if not sample["files"]:
-        return IngestUserException("Samples must specify filenames for local ingest")
-
-    file = sample["files"]["sample"]
-    index = sample["files"]["index"]
-    index_pattern = re.compile(f"(.+?)(\.tbi|\.bai|\.crai|\.csi)$")
-    index_parse = index_pattern.match(index)
-    if not index_parse:
-        return IngestUserException("Index invalid or not provided for sample %s" % sample["genomic_id"])
-    type = 'read'
-    if index_parse.group(2) == '.tbi':
+    bucket_objects = [object.object_name for object in client['client'].list_objects(client["bucket"])]
+    if (genomic_id not in bucket_objects) or ((genomic_id + '.' + index) not in bucket_objects):
+        return IngestUserException("Genomic file or index specified not found in bucket: "
+                                    f"{genomic_id} (index: {index})")
+    if index == "tbi":
         type = 'variant'
-    return [{
-            "id": sample["genomic_id"],
-            "file": os.path.basename(file),
-            "index": os.path.basename(index),
+    else:
+        type = 'read'
+    return {
+            "id": genomic_id,
+            "index": genomic_id + '.' + index,
             "type": type,
-            "file_access": f"file://{file}",
-            "index_access": f"file://{file}"
-        }]
+            "file_access": f"{client['endpoint']}/{client['bucket']}/{genomic_id}",
+            "index_access": f"{client['endpoint']}/{client['bucket']}/{genomic_id}.{index}"
+        }
 
-def htsget_ingest_from_file(dataset, token, samples, reference="hg38", indexing=False):
-    if os.getenv("CANDIG_URL") == "":
-        raise Exception("CANDIG_URL environment variable is not set")
-
-    created = []
-    for sample in samples:
-        if ((type(sample) != dict) or ("genomic_id" not in sample) or ("clinical_id" not in sample)):
-            return IngestUserException("Invalid sample data provided - see candigv2-ingest README.md")
-        if "files" not in sample:
-            sample["files"] = None
-        objects_to_create = collect_samples_for_genomic_id_local(sample)
-        if isinstance(objects_to_create, IngestResult):
-            return objects_to_create # An error occurred
-        if len(objects_to_create) == 0:
-            return IngestUserException("Sample file invalid: %s" % sample["genomic_id"])
-        response = post_objects(sample["genomic_id"], objects_to_create, token, clinical_id=sample["clinical_id"],
-                                ref_genome=reference,
-                                force=indexing)
-        if (response.status_code > 200):
-            print(response.text)
-            if response.status_code < 500:
-                return IngestUserException(response.text)
-            else:
-                return IngestServerException(response.text)
-        created.extend(map(lambda s: s['id'], objects_to_create))
-    response = post_to_dataset(created, dataset, token)
-    if response.status_code > 300:
-        print(response.text)
-        if response.status_code < 500:
-            return IngestUserException(response.text)
-        else:
-            return IngestServerException(response.text)
-    return IngestResult(str(created))
-
-
-def htsget_ingest_from_bucket(endpoint, bucket, dataset, token,
-                          samples, awsfile=None, access=None, secret=None, prefix="", reference="hg38", indexing=False):
-    if os.getenv("CANDIG_URL") == "":
-        raise Exception("CANDIG_URL environment variable is not set")
-
-    if awsfile:
-        # parse the awsfile:
-        result = auth.parse_aws_credential(awsfile)
-        access_key = result["access"]
-        secret_key = result["secret"]
-        if "error" in result:
-            return IngestServerException(f"Failed to parse awsfile: {result['error']}")
-    elif access and secret:
-        access_key = access
-        secret_key = secret
+def create_local_sample(genomic_id: str, index: str, path: str):
+    if index == "tbi":
+        type = 'variant'
     else:
-        return IngestUserException("Either awsfile or access/secret need to be provided.")
+        type = 'read'
+    return {
+            "id": genomic_id,
+            "file": genomic_id,
+            "index": genomic_id + '.' + index,
+            "type": type,
+            "file_access": f"file://{path}",
+            "index_access": f"file://{path} + '.' + index"
+        }
 
-    client = auth.get_minio_client(token, endpoint, bucket, access_key=access_key, secret_key=secret_key)
-    result, status_code = auth.store_aws_credential(token=token, endpoint=client["endpoint"], bucket=client["bucket"],
-                                                    access=client["access"], secret=client["secret"])
-    if status_code != 200:
-        return IngestServerException(f"Failed to add AWS credential to vault: {result}")
-    created = []
-    for sample in samples:
-        if ((type(sample) != dict) or ("genomic_id" not in sample)):
-            return IngestUserException("Invalid sample data provided - see candigv2-ingest README.md")
-        if "files" not in sample:
-            sample["files"] = None
-        if "clinical_id" not in sample:
-            sample["clinical_id"] = None
-        # first, find all of the s3 objects related to this sample:
-        objects_to_create = collect_samples_for_genomic_id(sample["genomic_id"], client, sample["files"], prefix=prefix)
-        if isinstance(objects_to_create, IngestResult):
-            return objects_to_create # An error occurred
-        if len(objects_to_create) == 0:
-            return IngestUserException("S3 bucket or sample list must not be empty")
-        response = post_objects(sample["genomic_id"], objects_to_create, token, clinical_id=sample["clinical_id"], ref_genome=reference,
-                     force=indexing)
-        if (response.status_code > 200):
-            print(response.text)
-            if response.status_code < 500:
-                return IngestUserException(response.text)
-            else:
-                return IngestServerException(response.text)
-        created.extend(map(lambda s: s['id'], objects_to_create))
-    response = post_to_dataset(created, dataset, token)
-    if response.status_code > 300:
-        print(response.text)
-        if response.status_code < 500:
-            return IngestUserException(response.text)
-        else:
-            return IngestServerException(response.text)
-    return IngestResult(str(created))
-
-@ingest_blueprint.route('/ingest_genomic', methods=["POST"])
-def genomic_ingest_endpoint():
-    if "Authorization" not in request.headers:
-        return {"result": "Refresh token required"}, 401
-    try:
-        token = request.headers["Authorization"].split("Bearer ")[1]
-    except Exception as e:
-        if ("Invalid bearer token" in str(e)) or (not request.headers["Authorization"].startswith("Bearer ")):
-            return {"result": "Bearer token invalid or unauthorized"}, 401
-        return {"result": "Unknown error during authorization"}, 401
-    """
-    (For new auth model)
-    try:
-        token = auth.get_bearer_from_refresh(token)
-    except Exception as e:
-        return {"result": "Error validating token: %s" % str(e)}, 401
-    """
-
-
-    req_values_s3 = {
-        "endpoint": "required",
-        "bucket": "required",
-        "dataset": "required",
-        "samples": "required",
-        "access": "required",
-        "secret": "required",
-        "prefix": "",
-        "reference": "hg38",
-        "indexing": False,
-    }
-
-    req_values_local = {
-        "dataset": "required",
-        "samples": "required",
-        "reference": "hg38",
-        "indexing": False,
-    }
+def htsget_ingest(token, dataset, sample, reference="hg38", indexing=False):
     local = False
-    if ("local" in request.json):
-        if (request.json["local"]):
-            local = True
-        request.json.pop("local")
-    if not local:
-        for arg in req_values_s3:
-            try:
-                req_values_s3[arg] = request.json[arg]
-            except KeyError:
-                if (req_values_s3[arg] == "required"):
-                    return {"result": "Parameter %s is required" % arg}, 400
-        req_values_s3["token"] = token
-        for arg in request.json:
-            if arg not in req_values_s3:
-                return {"result": "Invalid parameter: %s" % arg}
+    match = re.search("s3:\/\/(.+)\/(.+)", sample["access_method"])
+    if match:
+        endpoint = match.group(1)
+        bucket = match.group(2)
     else:
-        for arg in req_values_local:
-            try:
-                req_values_local[arg] = request.json[arg]
-            except KeyError:
-                if (req_values_local[arg] == "required"):
-                    return {"result": "Parameter %s is required" % arg}, 400
-        req_values_local["token"] = token
-        for arg in request.json:
-            if arg not in req_values_local:
-                return {"result": "Invalid parameter: %s" % arg}
+        local = True
+    if os.getenv("CANDIG_URL") == "":
+        raise Exception("CANDIG_URL environment variable is not set")
 
-    try:
-        if not local:
-            response = htsget_ingest_from_bucket(**req_values_s3)
+    if not local:
+        try:
+            client = auth.get_minio_client(token, endpoint, bucket)
+        except Exception as e:
+            print(e)
+            return IngestServerException("Failed to access S3 bucket %s. Did you add credentials to vault?" % bucket)
+        # first, find all of the s3 objects related to this sample:
+        object = create_s3_sample(sample["genomic_id"], sample["index"], client)
+    else:
+        object = create_local_sample(sample["genomic_id"], sample["index"], sample["access_method"].split("file://")[1])
+    if isinstance(object, IngestResult):
+        return object # An error occurred
+    response = post_object(token, object, sample["samples"], dataset, ref_genome=reference, force=indexing)
+    if (response.status_code > 200):
+        print(response.text)
+        if response.status_code < 500:
+            return IngestUserException(response.text)
         else:
-            response = htsget_ingest_from_file(**req_values_local)
-    except Exception as e:
-        traceback.print_exc()
-        return {"result": "Unknown error: %s" % str(e)}, 500
-
-    if type(response) == IngestResult:
-        return {"result": "Ingested genomic samples: %s" % response.value}, 200
-    elif type(response) == IngestUserException:
-        return {"result": "Data error: %s" % response.value}, 400
-    elif type(response) == IngestPermissionsException:
-        return {"result": "Error: You are not authorized to write to program." % response.value}, 403
-    elif type(response) == IngestServerException:
-        return {"result": "Ingest encountered the following errors: %s" % response.value}, 500
-    return 500
-
+            return IngestServerException(response.text)
+    response = post_to_dataset(object["id"], dataset, token)
+    if response.status_code > 300:
+        print(response.text)
+        if response.status_code < 500:
+            return IngestUserException(response.text)
+        else:
+            return IngestServerException(response.text)
+    return IngestResult(sample["genomic_id"])
 
 def main():
     parser = argparse.ArgumentParser(description="A script that ingests a sample vcf and its index into htsget.")
-
-    parser.add_argument("--local", help="Ingest from local directory", action='store_true', required=False)
-    parser.add_argument("--samplefile", help="A file specifying genomic/clinical IDs to ingest and optionally their filenames")
-    parser.add_argument("--endpoint", help="s3 endpoint", required=False)
-    parser.add_argument("--bucket", help="s3 bucket name", required=False)
-    parser.add_argument("--dataset", help="dataset name", required=True)
-    parser.add_argument("--awsfile", help="s3 credentials", required=False)
-    parser.add_argument("--access", help="access key", required=False)
-    parser.add_argument("--secret", help="secret key", required=False)
-    parser.add_argument("--region", help="optional: s3 region", required=False)
-    parser.add_argument("--prefix", help="optional: s3 prefix", required=False, default="")
+    parser.add_argument("--samplefile", help="A file specifying a genomic sample")
+    parser.add_argument("--dataset", help="dataset/cohort/program_id", required=True)
+    parser.add_argument("--region", help="optional: s3 region", required=False) # Not used?
     parser.add_argument("--reference", help="optional: reference genome, either hg37 or hg38", required=False, default="hg38")
     parser.add_argument("--indexing", action="store_true", help="optional: force re-indexing", required=False)
 
@@ -284,17 +96,10 @@ def main():
 
     if args.samplefile:
         with open(args.samplefile) as f:
-            genomic_samples = json.loads(f.read())
+            genomic_sample = json.loads(f.read())
 
-    if args.local:
-        result = htsget_ingest_from_file(args.dataset, auth.get_site_admin_token(),
-                                         genomic_samples, args.reference, args.indexing)
-    else:
-        result = htsget_ingest_from_bucket(args.endpoint, args.bucket, args.dataset,
-                                        auth.get_site_admin_token(),
-                                        genomic_samples, args.awsfile,
-                                        args.access, args.secret, args.prefix, args.reference,
-                                        args.indexing)
+    result = htsget_ingest(auth.get_site_admin_token(), args.dataset, genomic_sample, args.reference,
+                                    args.indexing)
     if result.value:
       print(result.value)
 

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -143,7 +143,8 @@ def htsget_ingest_from_bucket(endpoint, bucket, dataset, token,
         return IngestUserException("Either awsfile or access/secret need to be provided.")
 
     client = auth.get_minio_client(token, endpoint, bucket, access_key=access_key, secret_key=secret_key)
-    result, status_code = auth.store_aws_credential(token=token, client=client)
+    result, status_code = auth.store_aws_credential(token=token, endpoint=client["endpoint"], bucket=client["bucket"],
+                                                    access=client["access"], secret=client["secret"])
     if status_code != 200:
         return IngestServerException(f"Failed to add AWS credential to vault: {result}")
     created = []

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -128,7 +128,12 @@ components:
       content:
         'application/json':
           schema:
-            $ref: "#/components/schemas/DonorWithClinicalDataField"
+            type: object
+            properties:
+              donors:
+                $ref: "#/components/schemas/DonorWithClinicalDataField"
+            required:
+              - donors
   schemas:
     S3Access:
       type: string
@@ -139,6 +144,7 @@ components:
       type: array
       description: A DonorWithClinicalData Field (e.g. Donor, Biomarker, etc)
       items:
+        type: object
         properties:
           primary_diagnoses:
             $ref: '#/components/schemas/DonorWithClinicalDataField'

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -28,7 +28,7 @@ paths:
               application/json:
                 schema:
                   type: object
-  /ingest/{program_id}/moh_variants:
+  /ingest/moh_variants/{program_id}:
     post:
       description: Add a genomic file that corresponds to a SampleRegistration in an MoH Program schema.
       operationId: ingest_operations.add_moh_variant

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -21,6 +21,12 @@ paths:
       operationId: ingest_operations.add_s3_credential
       requestBody:
         $ref: '#/components/requestBodies/S3CredentialRequest'
+      parameters:
+        - in: header
+          name: Authorization
+          schema:
+            $ref: '#/components/schemas/BearerToken'
+          required: true
       responses:
           200:
             description: Success
@@ -190,3 +196,7 @@ components:
       required:
         - sample_registration_id
         - sample_name_in_file
+    BearerToken:
+      type: string
+      description: An Authorization BearerToken header
+      pattern: Bearer .+

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -43,6 +43,19 @@ paths:
               application/json:
                 schema:
                   type: object
+  /ingest/clinical_donors:
+    post:
+      description: Add a list of donors with clinical data produced by the clinical ETL.
+      operationId: ingest_operations.add_clinical_donors
+      requestBody:
+        $ref: "#/components/requestBodies/ClinicalDonorRequest"
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
 components:
   parameters:
     ProgramId:
@@ -100,12 +113,64 @@ components:
               - genomic_id
               - access_method
               - samples
+    ClinicalDonorRequest:
+      content:
+        'application/json':
+          schema:
+            $ref: "#/components/schemas/DonorWithClinicalDataField"
   schemas:
     S3Access:
       type: string
       description: a specification for an S3 bucket
       pattern: s3:\/\/(.+)\/(.+)
       example: s3://http://candig.docker.internal:9000/mohccn-data
+    DonorWithClinicalDataField: # "Sanity check" validation, everyting else happens in ETL validation/katsu
+      type: array
+      description: A DonorWithClinicalData Field (e.g. Donor, Biomarker, etc)
+      items:
+        properties:
+          primary_diagnoses:
+            $ref: '#/components/schemas/DonorWithClinicalDataField'
+          treatments:
+            $ref: '#/components/schemas/DonorWithClinicalDataField'
+          specimens:
+            $ref: '#/components/schemas/DonorWithClinicalDataField'
+          exposures:
+            $ref: '#/components/schemas/DonorWithClinicalDataField'
+          radiation:
+            type: object
+          surgeries:
+            $ref: '#/components/schemas/DonorWithClinicalDataField'
+          followups:
+            $ref: '#/components/schemas/DonorWithClinicalDataField'
+          comorbidities:
+            $ref: '#/components/schemas/DonorWithClinicalDataField'
+          hormone_therapies:
+            $ref: '#/components/schemas/DonorWithClinicalDataField'
+          immunotherapies:
+            $ref: '#/components/schemas/DonorWithClinicalDataField'
+          sample_registrations:
+            $ref: '#/components/schemas/DonorWithClinicalDataField'
+          biomarkers:
+            $ref: '#/components/schemas/DonorWithClinicalDataField'
+          chemotherapies:
+            $ref: '#/components/schemas/DonorWithClinicalDataField'
+          surgery:
+            type: object
+        additionalProperties:
+          oneOf:
+            - type: string
+              nullable: true
+            - type: number
+            - type: boolean
+            - type: array
+              items:
+                oneOf:
+                  - type: string
+                    nullable: true
+                  - type: number
+                  - type: boolean
+                  - type: array
     FileAccess:
       type: string
       description: a file path to a directory on the HTSGet server itself

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -104,8 +104,12 @@ components:
             properties:
               genomic_id:
                 type: string
-                description: the name of the VCF file, including gz, if present
+                description: The name of the VCF file, including gz, if present
                 example: "HG00096.vcf.gz"
+              index:
+                type: string
+                description: The extension of the index file without the dot (tbi, crai...)
+                example: "tbi"
               access_method:
                 type: string
                 anyOf:
@@ -119,6 +123,7 @@ components:
               - genomic_id
               - access_method
               - samples
+              - index
     ClinicalDonorRequest:
       content:
         'application/json':

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -2,6 +2,7 @@ import connexion
 from flask import request, Flask
 import os
 
+import auth
 from ingest_result import *
 from katsu_ingest import ingest_donor_with_clinical, setTrailingSlash
 import config
@@ -23,7 +24,9 @@ def get_service_info():
     }
 
 def add_s3_credential():
-    return None, 501
+    data = connexion.request.json
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+    return auth.store_aws_credential(data["endpoint"], data["bucket"], data["access_key"], data["secret_key"], token)
 
 def add_moh_variant(program_id):
     print(connexion.request.json)

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -61,7 +61,7 @@ def add_clinical_donors():
     if os.environ.get("KATSU_TRAILING_SLASH") == "TRUE":
         setTrailingSlash(True)
     katsu_server_url = os.environ.get("CANDIG_URL")
-    dataset = connexion.request.json
+    dataset = connexion.request.json["donors"]
     headers = {}
     if "Authorization" not in request.headers:
         return {"result": "Bearer token required"}, 401

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -25,3 +25,7 @@ def add_s3_credential():
 def add_moh_variant(program_id):
     print(connexion.request.json)
     return None, 501
+
+def add_clinical_donors():
+    print(connexion.request.json)
+    return None, 501

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -1,6 +1,9 @@
 import connexion
 from flask import request, Flask
+import os
 
+from ingest_result import *
+from katsu_ingest import ingest_donor_with_clinical, setTrailingSlash
 import config
 
 app = Flask(__name__)
@@ -27,5 +30,35 @@ def add_moh_variant(program_id):
     return None, 501
 
 def add_clinical_donors():
-    print(connexion.request.json)
-    return None, 501
+    if os.environ.get("KATSU_TRAILING_SLASH") == "TRUE":
+        setTrailingSlash(True)
+    katsu_server_url = os.environ.get("CANDIG_URL")
+    dataset = connexion.request.json
+    headers = {}
+    if "Authorization" not in request.headers:
+        return {"result": "Bearer token required"}, 401
+    try:
+        # New auth model
+        # refresh_token = request.headers["Authorization"].split("Bearer ")[1]
+        # token = auth.get_bearer_from_refresh(refresh_token)
+        token = request.headers["Authorization"].split("Bearer ")[1]
+        headers["Authorization"] = "Bearer %s" % token
+    except Exception as e:
+        if "Invalid bearer token" in str(e):
+            return {"result": "Bearer token invalid or unauthorized"}, 401
+        return {"result": "Unknown error during authorization"}, 401
+    headers["Content-Type"] = "application/json"
+    response = ingest_donor_with_clinical(katsu_server_url, dataset, headers)
+    if type(response) == IngestResult:
+        return {"result": "Ingested %d donors." % response.value}, 200
+    elif type(response) == IngestPermissionsException:
+        return {"result": "Permissions error: %s" % response.value, "note": "Data may be \
+partially ingested. You may need to delete the relevant programs in Katsu."}, 403
+    elif type(response) == IngestServerException:
+        error_string = ','.join(response.value)
+        return {"result": "Ingest encountered the following errors: %s" % error_string, "note": "Data may be partially \
+ingested. You may need to delete the relevant programs in Katsu. This was an internal error, so you may want to report \
+this issue to a CanDIG developer."}, 500
+    elif type(response) == IngestUserException:
+        return {"result": "Data error: %s" % response.value}, 400
+    return "Unknown error", 500

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -384,10 +384,9 @@ def main():
         choices=range(1, 4),
         help="Select an option: 1=Run check, 2=Ingest data, 3=Delete a dataset, 4=Ingest DonorWithClinicalData",
     )
-    parser.add_argument("--katsu_trailing_slash", type=bool, dest="katsu_trailing_slash",
-                        help="Set if Katsu uses a trailing slash after its endpoints")
+    parser.add_argument("--katsu_trailing_slash", dest="katsu_trailing_slash",
+                        help="Set if Katsu uses a trailing slash after its endpoints", action='store_true')
     args = parser.parse_args()
-
     if args.katsu_trailing_slash:
         setTrailingSlash(args.katsu_trailing_slash)
 

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -425,7 +425,7 @@ def main():
             print("Delete cancelled")
             exit()
     elif choice == 4:
-        dataset = read_json(data_location)
+        dataset = read_json(data_location)["donors"]
         headers["Content-Type"] = "application/json"
         print(ingest_donor_with_clinical(katsu_server_url, dataset, headers).value)
     elif choice == 5:

--- a/single_ingest.json
+++ b/single_ingest.json
@@ -1,3065 +1,3060 @@
-[
-		{
-			"submitter_donor_id": "DONOR_1",
-			"program_id": "SYNTHETIC-2",
-			"lost_to_followup_after_clinical_event_identifier": "",
-			"lost_to_followup_reason": "Not applicable",
-			"date_alive_after_lost_to_followup": "2022-02",
-			"is_deceased": true,
-			"cause_of_death": "Unknown",
-			"date_of_birth": "1961-07",
-			"date_of_death": "2009-07",
-			"gender": "Woman",
-			"sex_at_birth": "Unknown",
-			"primary_site": [
-				"Corpus uteri",
-				"Anus and anal canal"
-			],
-			"primary_diagnoses": [
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_1",
-					"date_of_diagnosis": "2019-06",
-					"cancer_type_code": "C02.1",
-					"basis_of_diagnosis": "Histology of a metastasis",
-					"lymph_nodes_examined_status": "No lymph nodes found in resected specimen",
-					"lymph_nodes_examined_method": "Lymph node dissection/pathological exam",
-					"number_lymph_nodes_positive": 10,
-					"clinical_tumour_staging_system": "FIGO staging system",
-					"clinical_t_category": "TX",
-					"clinical_n_category": "N1mi",
-					"clinical_m_category": "M1a",
-					"clinical_stage_group": "Stage IIIAES",
-					"laterality": "Unilateral, side not specified",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_1",
-							"pathological_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
-							"pathological_t_category": "T4a",
-							"pathological_n_category": "N1",
-							"pathological_m_category": "MX",
-							"pathological_stage_group": "Stage IIAE",
-							"specimen_collection_date": "2021-06-01",
-							"specimen_storage": "Frozen in liquid nitrogen",
-							"tumour_histological_type": "8820/3",
-							"specimen_anatomic_location": "C67.6",
-							"reference_pathology_confirmed_diagnosis": "Not done",
-							"reference_pathology_confirmed_tumour_presence": "Unknown",
-							"tumour_grading_system": "Grading system for GISTs",
-							"tumour_grade": "Grade 3",
-							"percent_tumour_cells_range": "0-19%",
-							"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
-							"specimen_processing": "Cryopreservation in liquid nitrogen (dead tissue)",
-							"specimen_laterality": "Right",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_1",
-									"specimen_tissue_source": "Pleural fluid",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Cell line - derived from normal",
-									"sample_type": "Other DNA enrichments"
-								},
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_2",
-									"specimen_tissue_source": "Seminal fluid",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Xenograft - derived from metastatic tumour",
-									"sample_type": "rRNA-depleted RNA"
-								},
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_3",
-									"specimen_tissue_source": "Seminal fluid",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Primary tumour",
-									"sample_type": "Total DNA"
-								},
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_4",
-									"specimen_tissue_source": "Seminal fluid",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Normal - tissue adjacent to primary tumour",
-									"sample_type": "Total DNA"
-								}
-							],
-							"biomarkers": [
-								{
-									"er_status": "Cannot be determined",
-									"pr_status": "Not applicable",
-									"her2_ihc_status": "Equivocal",
-									"her2_ish_status": "Unknown",
-									"hpv_ihc_status": "Not applicable",
-									"hpv_pcr_status": "Unknown",
-									"hpv_strain": [
-										"HPV68"
-									],
-									"test_interval": 7,
-									"psa_level": 343,
-									"ca125": 58,
-									"cea": 9,
-									"er_percent_positive": 19.1,
-									"pr_percent_positive": 17.9
-								},
-								{
-									"er_status": "Unknown",
-									"pr_status": "Not applicable",
-									"her2_ihc_status": "Equivocal",
-									"her2_ish_status": "Positive",
-									"hpv_ihc_status": "Not applicable",
-									"hpv_pcr_status": "Negative",
-									"hpv_strain": [
-										"HPV18"
-									],
-									"test_interval": 6,
-									"psa_level": 399,
-									"ca125": 73,
-									"cea": 8,
-									"er_percent_positive": 45.5,
-									"pr_percent_positive": 52.5
-								}
-							]
-						},
-						{
-							"submitter_specimen_id": "SPECIMEN_2",
-							"pathological_tumour_staging_system": "AJCC 7th edition",
-							"pathological_t_category": "T4a",
-							"pathological_n_category": "N2a",
-							"pathological_m_category": "M1d",
-							"pathological_stage_group": "Stage IIIC2",
-							"specimen_collection_date": "2020-06-30",
-							"specimen_storage": "Not Applicable",
-							"tumour_histological_type": "8980/2",
-							"specimen_anatomic_location": "C43.9",
-							"reference_pathology_confirmed_diagnosis": "No",
-							"reference_pathology_confirmed_tumour_presence": "Unknown",
-							"tumour_grading_system": "IASLC grading system",
-							"tumour_grade": "Grade Group 5",
-							"percent_tumour_cells_range": "20-50%",
-							"percent_tumour_cells_measurement_method": "Unknown",
-							"specimen_processing": "Fresh",
-							"specimen_laterality": "Not applicable",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_4",
-									"specimen_tissue_source": "Hydrocele fluid",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Normal",
-									"sample_type": "Other DNA enrichments"
-								},
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_5",
-									"specimen_tissue_source": "Sputum",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Normal",
-									"sample_type": "Total RNA"
-								},
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_6",
-									"specimen_tissue_source": "Cervical mucus",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Recurrent tumour",
-									"sample_type": "Total DNA"
-								}
-							],
-							"biomarkers": []
-						},
-						{
-							"submitter_specimen_id": "SPECIMEN_3",
-							"pathological_tumour_staging_system": "AJCC 7th edition",
-							"pathological_t_category": "T1a2",
-							"pathological_n_category": "N2c",
-							"pathological_m_category": "M1a(1)",
-							"pathological_stage_group": "Stage IIBE",
-							"specimen_collection_date": "2020-10-26",
-							"specimen_storage": "Frozen in vapour phase",
-							"tumour_histological_type": "8209/3",
-							"specimen_anatomic_location": "C43.9",
-							"reference_pathology_confirmed_diagnosis": "Not done",
-							"reference_pathology_confirmed_tumour_presence": "Yes",
-							"tumour_grading_system": "Nuclear grading system for DCIS",
-							"tumour_grade": "G3",
-							"percent_tumour_cells_range": "51-100%",
-							"percent_tumour_cells_measurement_method": "Image analysis",
-							"specimen_processing": "Formalin fixed - unbuffered",
-							"specimen_laterality": "Left",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_7",
-									"specimen_tissue_source": "Vitreous fluid",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Metastatic tumour - metastasis to distant location",
-									"sample_type": "polyA+ RNA"
-								},
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_8",
-									"specimen_tissue_source": "Seminal fluid",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Normal - tissue adjacent to primary tumour",
-									"sample_type": "Total DNA"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_1",
-							"is_primary_treatment": "Unknown",
-							"treatment_start_date": "2021-01",
-							"treatment_end_date": "2022-08",
-							"treatment_setting": "Mobilization",
-							"treatment_intent": "Screening",
-							"days_per_cycle": 4,
-							"number_of_cycles": 5,
-							"line_of_treatment": 5,
-							"status_of_treatment": "Other",
-							"treatment_type": [
-								"Bone marrow transplant",
-								"Photodynamic therapy"
-							],
-							"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
-							"response_to_treatment": "Complete response",
-							"chemotherapies": [
-								{
-									"chemotherapy_drug_dose_units": "ug/m2",
-									"drug_reference_database": "NCI Thesaurus",
-									"drug_name": "LEUCOVORIN",
-									"drug_reference_identifier": "876459",
-									"prescribed_cumulative_drug_dose": 4600,
-									"actual_cumulative_drug_dose": 66
-								},
-								{
-									"chemotherapy_drug_dose_units": "ug/m2",
-									"drug_reference_database": "PubChem",
-									"drug_name": "FLUOROURACIL",
-									"drug_reference_identifier": "87354",
-									"prescribed_cumulative_drug_dose": 150,
-									"actual_cumulative_drug_dose": 94
-								},
-								{
-									"chemotherapy_drug_dose_units": "mg/m2",
-									"drug_reference_database": "PubChem",
-									"drug_name": "LIPOSOMAL IRINOTECAN",
-									"drug_reference_identifier": "7365837",
-									"prescribed_cumulative_drug_dose": 320,
-									"actual_cumulative_drug_dose": 60
-								}
-							],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_1",
-									"date_of_followup": "2022-08",
-									"disease_status_at_followup": "Loco-regional progression",
-									"relapse_type": "Distant recurrence/metastasis",
-									"date_of_relapse": "2022-01",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C06",
-									"recurrence_tumour_staging_system": "SEER staging system",
-									"recurrence_t_category": "T2(m)",
-									"recurrence_n_category": "N2c",
-									"recurrence_m_category": "M1b(1)",
-									"recurrence_stage_group": "Stage IIBES",
-									"biomarkers": [
-										{
-											"er_status": "Negative",
-											"pr_status": "Unknown",
-											"her2_ihc_status": "Negative",
-											"her2_ish_status": "Equivocal",
-											"hpv_ihc_status": "Negative",
-											"hpv_pcr_status": "Positive",
-											"hpv_strain": [
-												"HPV31",
-												"HPV68"
-											],
-											"test_interval": 5,
-											"psa_level": 318,
-											"ca125": 78,
-											"cea": 13,
-											"er_percent_positive": 12.4,
-											"pr_percent_positive": 11.0
-										},
-										{
-											"er_status": "Cannot be determined",
-											"pr_status": "Unknown",
-											"her2_ihc_status": "Equivocal",
-											"her2_ish_status": "Negative",
-											"hpv_ihc_status": "Not applicable",
-											"hpv_pcr_status": "Negative",
-											"hpv_strain": [
-												"HPV35"
-											],
-											"test_interval": 4,
-											"psa_level": 379,
-											"ca125": 106,
-											"cea": 4,
-											"er_percent_positive": 18.3,
-											"pr_percent_positive": 65.2
-										},
-										{
-											"er_status": "Cannot be determined",
-											"pr_status": "Not applicable",
-											"her2_ihc_status": "Not applicable",
-											"her2_ish_status": "Cannot be determined",
-											"hpv_ihc_status": "Cannot be determined",
-											"hpv_pcr_status": "Unknown",
-											"hpv_strain": [
-												"HPV18"
-											],
-											"test_interval": 8,
-											"psa_level": 328,
-											"ca125": 104,
-											"cea": 13,
-											"er_percent_positive": 21.0,
-											"pr_percent_positive": 32.7
-										}
-									]
-								},
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_2",
-									"date_of_followup": "2022-11",
-									"disease_status_at_followup": "Loco-regional progression",
-									"relapse_type": "Biochemical progression",
-									"date_of_relapse": "2022-05",
-									"method_of_progression_status": [
-										"Imaging (procedure)",
-										"Laboratory data interpretation (procedure)"
-									],
-									"anatomic_site_progression_or_recurrence": "C05",
-									"recurrence_tumour_staging_system": "Lugano staging system",
-									"recurrence_t_category": "T1d",
-									"recurrence_n_category": "N1mi",
-									"recurrence_m_category": "M1a(0)",
-									"recurrence_stage_group": "Stage IVBS",
-									"biomarkers": [
-										{
-											"er_status": "Positive",
-											"pr_status": "Positive",
-											"her2_ihc_status": "Not applicable",
-											"her2_ish_status": "Equivocal",
-											"hpv_ihc_status": "Unknown",
-											"hpv_pcr_status": "Not applicable",
-											"hpv_strain": [
-												"HPV73"
-											],
-											"test_interval": 5,
-											"psa_level": 351,
-											"ca125": 81,
-											"cea": 7,
-											"er_percent_positive": 97.8,
-											"pr_percent_positive": 32.9
-										},
-										{
-											"er_status": "Not applicable",
-											"pr_status": "Cannot be determined",
-											"her2_ihc_status": "Positive",
-											"her2_ish_status": "Unknown",
-											"hpv_ihc_status": "Cannot be determined",
-											"hpv_pcr_status": "Positive",
-											"hpv_strain": [
-												"HPV68"
-											],
-											"test_interval": 8,
-											"psa_level": 326,
-											"ca125": 96,
-											"cea": 11,
-											"er_percent_positive": 13.7,
-											"pr_percent_positive": 85.4
-										},
-										{
-											"er_status": "Unknown",
-											"pr_status": "Not applicable",
-											"her2_ihc_status": "Equivocal",
-											"her2_ish_status": "Unknown",
-											"hpv_ihc_status": "Negative",
-											"hpv_pcr_status": "Unknown",
-											"hpv_strain": [
-												"HPV68",
-												"HPV18"
-											],
-											"test_interval": 7,
-											"psa_level": 212,
-											"ca125": 54,
-											"cea": 8,
-											"er_percent_positive": 5.3,
-											"pr_percent_positive": 74.3
-										}
-									]
-								},
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_3",
-									"date_of_followup": "2022-10",
-									"disease_status_at_followup": "No evidence of disease",
-									"relapse_type": "Local recurrence and distant metastasis",
-									"date_of_relapse": "2022-07",
-									"method_of_progression_status": [
-										"Histopathology test (procedure)",
-										"Assessment of symptom control (procedure)"
-									],
-									"anatomic_site_progression_or_recurrence": "C18",
-									"recurrence_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
-									"recurrence_t_category": "T1b2",
-									"recurrence_n_category": "N1b",
-									"recurrence_m_category": "M0",
-									"recurrence_stage_group": "Stage IIEA",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": [
-								{
-									"er_status": "Cannot be determined",
-									"pr_status": "Not applicable",
-									"her2_ihc_status": "Equivocal",
-									"her2_ish_status": "Unknown",
-									"hpv_ihc_status": "Not applicable",
-									"hpv_pcr_status": "Unknown",
-									"hpv_strain": [
-										"HPV68"
-									],
-									"test_interval": 7,
-									"psa_level": 343,
-									"ca125": 58,
-									"cea": 9,
-									"er_percent_positive": 19.1,
-									"pr_percent_positive": 17.9
-								},
-								{
-									"er_status": "Unknown",
-									"pr_status": "Not applicable",
-									"her2_ihc_status": "Equivocal",
-									"her2_ish_status": "Positive",
-									"hpv_ihc_status": "Not applicable",
-									"hpv_pcr_status": "Negative",
-									"hpv_strain": [
-										"HPV18"
-									],
-									"test_interval": 6,
-									"psa_level": 399,
-									"ca125": 73,
-									"cea": 8,
-									"er_percent_positive": 45.5,
-									"pr_percent_positive": 52.5
-								}
-							]
-						},
-						{
-							"submitter_treatment_id": "TREATMENT_2",
-							"is_primary_treatment": "Yes",
-							"treatment_start_date": "2021-12",
-							"treatment_end_date": "2022-10",
-							"treatment_setting": "Conditioning",
-							"treatment_intent": "Palliative",
-							"days_per_cycle": 4,
-							"number_of_cycles": 3,
-							"line_of_treatment": 3,
-							"status_of_treatment": "Treatment stopped due to acute toxicity",
-							"treatment_type": [
-								"Radiation therapy",
-								"Other targeting molecular therapy",
-								"Hormonal therapy"
-							],
-							"response_to_treatment_criteria_method": "Cheson CLL 2012 Oncology Response Criteria",
-							"response_to_treatment": "Major response",
-							"chemotherapies": [
-								{
-									"chemotherapy_drug_dose_units": "IU/kg",
-									"drug_reference_database": "PubChem",
-									"drug_name": "NIVOLUMAB",
-									"drug_reference_identifier": "7365837",
-									"prescribed_cumulative_drug_dose": 150,
-									"actual_cumulative_drug_dose": 111
-								},
-								{
-									"chemotherapy_drug_dose_units": "mg/m2",
-									"drug_reference_database": "NCI Thesaurus",
-									"drug_name": "FLUOROURACIL",
-									"drug_reference_identifier": "836754",
-									"prescribed_cumulative_drug_dose": 4600,
-									"actual_cumulative_drug_dose": 90
-								}
-							],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_4",
-									"date_of_followup": "2022-11",
-									"disease_status_at_followup": "Distant progression",
-									"relapse_type": "Progression (liquid tumours)",
-									"date_of_relapse": "2021-12",
-									"method_of_progression_status": [
-										"Tumor marker measurement (procedure)",
-										"Physical examination procedure (procedure)"
-									],
-									"anatomic_site_progression_or_recurrence": "C10",
-									"recurrence_tumour_staging_system": "Rai staging system",
-									"recurrence_t_category": "T2b",
-									"recurrence_n_category": "N2mi",
-									"recurrence_m_category": "M1d",
-									"recurrence_stage_group": "Stage IIIS",
-									"biomarkers": []
-								},
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_5",
-									"date_of_followup": "2022-11",
-									"disease_status_at_followup": "Distant progression",
-									"relapse_type": "Progression (liquid tumours)",
-									"date_of_relapse": "2022-05",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C08",
-									"recurrence_tumour_staging_system": "AJCC 6th edition",
-									"recurrence_t_category": "T2a1",
-									"recurrence_n_category": "N0b",
-									"recurrence_m_category": "M1e",
-									"recurrence_stage_group": "Stage IIB",
-									"biomarkers": []
-								},
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_6",
-									"date_of_followup": "2022-08",
-									"disease_status_at_followup": "No evidence of disease",
-									"relapse_type": "Local recurrence and distant metastasis",
-									"date_of_relapse": "2022-10",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C13",
-									"recurrence_tumour_staging_system": "Revised International staging system (RISS)",
-									"recurrence_t_category": "T2(m)",
-									"recurrence_n_category": "N1a",
-									"recurrence_m_category": "M1",
-									"recurrence_stage_group": "Stage 0is",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": [
-								{
-									"er_status": "Positive",
-									"pr_status": "Unknown",
-									"her2_ihc_status": "Cannot be determined",
-									"her2_ish_status": "Not applicable",
-									"hpv_ihc_status": "Not applicable",
-									"hpv_pcr_status": "Negative",
-									"hpv_strain": [
-										"HPV51"
-									],
-									"test_interval": 7,
-									"psa_level": 207,
-									"ca125": 112,
-									"cea": 9,
-									"er_percent_positive": 73.5,
-									"pr_percent_positive": 72.8
-								},
-								{
-									"er_status": "Positive",
-									"pr_status": "Not applicable",
-									"her2_ihc_status": "Unknown",
-									"her2_ish_status": "Equivocal",
-									"hpv_ihc_status": "Not applicable",
-									"hpv_pcr_status": "Cannot be determined",
-									"hpv_strain": [
-										"HPV33"
-									],
-									"test_interval": 7,
-									"psa_level": 327,
-									"ca125": 103,
-									"cea": 8,
-									"er_percent_positive": 65.8,
-									"pr_percent_positive": 23.6
-								}
-							]
-						},
-						{
-							"submitter_treatment_id": "TREATMENT_3",
-							"is_primary_treatment": "Yes",
-							"treatment_start_date": "2021-09",
-							"treatment_end_date": "2022-10",
-							"treatment_setting": "Maintenance",
-							"treatment_intent": "Palliative",
-							"days_per_cycle": 4,
-							"number_of_cycles": 4,
-							"line_of_treatment": 3,
-							"status_of_treatment": "Physician decision (stopped or interrupted treatment)",
-							"treatment_type": [
-								"Bone marrow transplant",
-								"Other targeting molecular therapy",
-								"Radiation therapy"
-							],
-							"response_to_treatment_criteria_method": "iRECIST",
-							"response_to_treatment": "Morphologic leukemia-free state",
-							"chemotherapies": [
-								{
-									"chemotherapy_drug_dose_units": "mg/m2",
-									"drug_reference_database": "PubChem",
-									"drug_name": "GEMCITABINE",
-									"drug_reference_identifier": "836754",
-									"prescribed_cumulative_drug_dose": 780,
-									"actual_cumulative_drug_dose": 78
-								}
-							],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_7",
-									"date_of_followup": "2022-10",
-									"disease_status_at_followup": "No evidence of disease",
-									"relapse_type": "Biochemical progression",
-									"date_of_relapse": "2022-08",
-									"method_of_progression_status": [
-										"Laboratory data interpretation (procedure)"
-									],
-									"anatomic_site_progression_or_recurrence": "C12",
-									"recurrence_tumour_staging_system": "St Jude staging system",
-									"recurrence_t_category": "Tis pu",
-									"recurrence_n_category": "N1a(sn)",
-									"recurrence_m_category": "M1a(0)",
-									"recurrence_stage_group": "Stage IAB",
-									"biomarkers": []
-								},
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_8",
-									"date_of_followup": "2022-11",
-									"disease_status_at_followup": "Distant progression",
-									"relapse_type": "Progression (liquid tumours)",
-									"date_of_relapse": "2022-03",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C01",
-									"recurrence_tumour_staging_system": "SEER staging system",
-									"recurrence_t_category": "T1",
-									"recurrence_n_category": "N1b",
-									"recurrence_m_category": "M1b(1)",
-									"recurrence_stage_group": "Stage L1",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				},
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_2",
-					"date_of_diagnosis": "2019-03",
-					"cancer_type_code": "C02.2",
-					"basis_of_diagnosis": "Clinical investigation",
-					"lymph_nodes_examined_status": "Not applicable",
-					"lymph_nodes_examined_method": "Physical palpation of patient",
-					"number_lymph_nodes_positive": 5,
-					"clinical_tumour_staging_system": "International Neuroblastoma Staging System",
-					"clinical_t_category": "T1b",
-					"clinical_n_category": "N2",
-					"clinical_m_category": "M1d(1)",
-					"clinical_stage_group": "Stage Ms",
-					"laterality": "Left",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_4",
-							"pathological_tumour_staging_system": "SEER staging system",
-							"pathological_t_category": "T2a2",
-							"pathological_n_category": "N0(i+)",
-							"pathological_m_category": "M1b",
-							"pathological_stage_group": "Stage IAS",
-							"specimen_collection_date": "2021-05-10",
-							"specimen_storage": "Unknown",
-							"tumour_histological_type": "8980/9",
-							"specimen_anatomic_location": "C43.9",
-							"reference_pathology_confirmed_diagnosis": "Yes",
-							"reference_pathology_confirmed_tumour_presence": "Not done",
-							"tumour_grading_system": "Grading system for GISTs",
-							"tumour_grade": "Low",
-							"percent_tumour_cells_range": "0-19%",
-							"percent_tumour_cells_measurement_method": "Unknown",
-							"specimen_processing": "Cryopreservation of live cells in liquid nitrogen",
-							"specimen_laterality": "Right",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_10",
-									"specimen_tissue_source": "Pleural fluid",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Metastatic tumour - metastasis local to lymph node",
-									"sample_type": "Total DNA"
-								},
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_9",
-									"specimen_tissue_source": "Buffy coat",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Metastatic tumour - metastasis to distant location",
-									"sample_type": "rRNA-depleted RNA"
-								}
-							],
-							"biomarkers": []
-						},
-						{
-							"submitter_specimen_id": "SPECIMEN_5",
-							"pathological_tumour_staging_system": "AJCC 6th edition",
-							"pathological_t_category": "Tis(DCIS)",
-							"pathological_n_category": "N0a",
-							"pathological_m_category": "M1c",
-							"pathological_stage_group": "Stage II bulky",
-							"specimen_collection_date": "2021-02-13",
-							"specimen_storage": "Unknown",
-							"tumour_histological_type": "8620/9",
-							"specimen_anatomic_location": "C34.9",
-							"reference_pathology_confirmed_diagnosis": "No",
-							"reference_pathology_confirmed_tumour_presence": "Yes",
-							"tumour_grading_system": "Gleason grade group system",
-							"tumour_grade": "Grade Group 5",
-							"percent_tumour_cells_range": "20-50%",
-							"percent_tumour_cells_measurement_method": "Image analysis",
-							"specimen_processing": "Cryopreservation in dry ice (dead tissue)",
-							"specimen_laterality": "Not applicable",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_11",
-									"specimen_tissue_source": "Buffy coat",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Normal - tissue adjacent to primary tumour",
-									"sample_type": "polyA+ RNA"
-								}
-							],
-							"biomarkers": []
-						},
-						{
-							"submitter_specimen_id": "SPECIMEN_6",
-							"pathological_tumour_staging_system": "AJCC 7th edition",
-							"pathological_t_category": "T3e",
-							"pathological_n_category": "N3a",
-							"pathological_m_category": "M1",
-							"pathological_stage_group": "Stage IVAS",
-							"specimen_collection_date": "2020-10-18",
-							"specimen_storage": "RNA later frozen",
-							"tumour_histological_type": "8620/9",
-							"specimen_anatomic_location": "C67.6",
-							"reference_pathology_confirmed_diagnosis": "Yes",
-							"reference_pathology_confirmed_tumour_presence": "No",
-							"tumour_grading_system": "Four-tier grading system",
-							"tumour_grade": "Grade 4",
-							"percent_tumour_cells_range": "51-100%",
-							"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
-							"specimen_processing": "Cryopreservation in dry ice (dead tissue)",
-							"specimen_laterality": "Unknown",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_12",
-									"specimen_tissue_source": "Amniotic fluid",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Primary tumour - additional new primary",
-									"sample_type": "Protein"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_4",
-							"is_primary_treatment": "No",
-							"treatment_start_date": "2021-09",
-							"treatment_end_date": "2022-09",
-							"treatment_setting": "Radiosensitization",
-							"treatment_intent": "Guidance",
-							"days_per_cycle": 4,
-							"number_of_cycles": 5,
-							"line_of_treatment": 5,
-							"status_of_treatment": "Physician decision (stopped or interrupted treatment)",
-							"treatment_type": [
-								"Surgery",
-								"Radiation therapy"
-							],
-							"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
-							"response_to_treatment": "Physician assessed partial response",
-							"chemotherapies": [
-								{
-									"chemotherapy_drug_dose_units": "mg/m2",
-									"drug_reference_database": "PubChem",
-									"drug_name": "NIVOLUMAB",
-									"drug_reference_identifier": "87354",
-									"prescribed_cumulative_drug_dose": 150,
-									"actual_cumulative_drug_dose": 111
-								}
-							],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_10",
-									"date_of_followup": "2022-08",
-									"disease_status_at_followup": "Distant progression",
-									"relapse_type": "Local recurrence and distant metastasis",
-									"date_of_relapse": "2022-08",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C01",
-									"recurrence_tumour_staging_system": "Binet staging system",
-									"recurrence_t_category": "T1a(s)",
-									"recurrence_n_category": "N4",
-									"recurrence_m_category": "M0(i+)",
-									"recurrence_stage_group": "Stage IE",
-									"biomarkers": []
-								},
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_9",
-									"date_of_followup": "2022-11",
-									"disease_status_at_followup": "Distant progression",
-									"relapse_type": "Progression (liquid tumours)",
-									"date_of_relapse": "2022-08",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C10",
-									"recurrence_tumour_staging_system": "Revised International staging system (RISS)",
-									"recurrence_t_category": "T2b",
-									"recurrence_n_category": "N2c",
-									"recurrence_m_category": "MX",
-									"recurrence_stage_group": "Stage IBS",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						},
-						{
-							"submitter_treatment_id": "TREATMENT_5",
-							"is_primary_treatment": "No",
-							"treatment_start_date": "2021-05",
-							"treatment_end_date": "2022-05",
-							"treatment_setting": "Conditioning",
-							"treatment_intent": "Curative",
-							"days_per_cycle": 5,
-							"number_of_cycles": 5,
-							"line_of_treatment": 1,
-							"status_of_treatment": "Treatment stopped due to acute toxicity",
-							"treatment_type": [
-								"Surgery",
-								"Radiation therapy"
-							],
-							"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
-							"response_to_treatment": "Stable disease",
-							"chemotherapies": [],
-							"hormone_therapies": [
-								{
-									"hormone_drug_dose_units": "IU/kg",
-									"drug_reference_database": "RxNorm",
-									"drug_name": "leuprolide",
-									"drug_reference_identifier": "258494",
-									"prescribed_cumulative_drug_dose": 160,
-									"actual_cumulative_drug_dose": 73
-								},
-								{
-									"hormone_drug_dose_units": "mg/m2",
-									"drug_reference_database": "PubChem",
-									"drug_name": "degarelix",
-									"drug_reference_identifier": "258494",
-									"prescribed_cumulative_drug_dose": 106,
-									"actual_cumulative_drug_dose": 114
-								},
-								{
-									"hormone_drug_dose_units": "ug/m2",
-									"drug_reference_database": "PubChem",
-									"drug_name": "degarelix",
-									"drug_reference_identifier": "46475",
-									"prescribed_cumulative_drug_dose": 179,
-									"actual_cumulative_drug_dose": 97
-								}
-							],
-							"immunotherapies": [],
-
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_11",
-									"date_of_followup": "2022-10",
-									"disease_status_at_followup": "Relapse or recurrence",
-									"relapse_type": "Local recurrence and distant metastasis",
-									"date_of_relapse": "2022-02",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C13",
-									"recurrence_tumour_staging_system": "Revised International staging system (RISS)",
-									"recurrence_t_category": "T4a(s)",
-									"recurrence_n_category": "N4",
-									"recurrence_m_category": "M1b",
-									"recurrence_stage_group": "Stage IVA",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						},
-						{
-							"submitter_treatment_id": "TREATMENT_6",
-							"is_primary_treatment": "Unknown",
-							"treatment_start_date": "2021-04",
-							"treatment_end_date": "2022-10",
-							"treatment_setting": "Neoadjuvant",
-							"treatment_intent": "Guidance",
-							"days_per_cycle": 3,
-							"number_of_cycles": 3,
-							"line_of_treatment": 1,
-							"status_of_treatment": "Unknown",
-							"treatment_type": [
-								"Radiation therapy",
-								"Surgery"
-							],
-							"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
-							"response_to_treatment": "Immune partial response (iPR)",
-							"chemotherapies": [],
-							"hormone_therapies": [
-								{
-									"hormone_drug_dose_units": "IU/m2",
-									"drug_reference_database": "PubChem",
-									"drug_name": "leuprolide",
-									"drug_reference_identifier": "258494",
-									"prescribed_cumulative_drug_dose": 71,
-									"actual_cumulative_drug_dose": 92
-								},
-								{
-									"hormone_drug_dose_units": "g/m2",
-									"drug_reference_database": "NCI Thesaurus",
-									"drug_name": "triptorelin",
-									"drug_reference_identifier": "258494",
-									"prescribed_cumulative_drug_dose": 76,
-									"actual_cumulative_drug_dose": 156
-								}
-							],
-							"immunotherapies": [],
-
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_12",
-									"date_of_followup": "2022-08",
-									"disease_status_at_followup": "Stable",
-									"relapse_type": "Local recurrence",
-									"date_of_relapse": "2022-05",
-									"method_of_progression_status": [
-										"Physical examination procedure (procedure)"
-									],
-									"anatomic_site_progression_or_recurrence": "C06",
-									"recurrence_tumour_staging_system": "Rai staging system",
-									"recurrence_t_category": "T3e",
-									"recurrence_n_category": "N1b",
-									"recurrence_m_category": "M1c",
-									"recurrence_stage_group": "Stage A",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				},
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_3",
-					"date_of_diagnosis": "2019-09",
-					"cancer_type_code": "C64.9",
-					"basis_of_diagnosis": "Clinical investigation",
-					"lymph_nodes_examined_status": "No lymph nodes found in resected specimen",
-					"lymph_nodes_examined_method": "Lymph node dissection/pathological exam",
-					"number_lymph_nodes_positive": 9,
-					"clinical_tumour_staging_system": "FIGO staging system",
-					"clinical_t_category": "T1d",
-					"clinical_n_category": "N1a(sn)",
-					"clinical_m_category": "M0(i+)",
-					"clinical_stage_group": "Stage IIE",
-					"laterality": "Left",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_7",
-							"pathological_tumour_staging_system": "AJCC 6th edition",
-							"pathological_t_category": "Tis(LCIS)",
-							"pathological_n_category": "N2b",
-							"pathological_m_category": "M1a(0)",
-							"pathological_stage_group": "Stage L1",
-							"specimen_collection_date": "2020-10-19",
-							"specimen_storage": "Frozen in -70 freezer",
-							"tumour_histological_type": "8830/6",
-							"specimen_anatomic_location": "C50.9",
-							"reference_pathology_confirmed_diagnosis": "Unknown",
-							"reference_pathology_confirmed_tumour_presence": "Not done",
-							"tumour_grading_system": "Four-tier grading system",
-							"tumour_grade": "G4",
-							"percent_tumour_cells_range": "0-19%",
-							"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
-							"specimen_processing": "Cryopreservation of live cells in liquid nitrogen",
-							"specimen_laterality": "Unknown",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_13",
-									"specimen_tissue_source": "Saliva",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Recurrent tumour",
-									"sample_type": "ctDNA"
-								}
-							],
-							"biomarkers": []
-						},
-						{
-							"submitter_specimen_id": "SPECIMEN_8",
-							"pathological_tumour_staging_system": "Lugano staging system",
-							"pathological_t_category": "T4e",
-							"pathological_n_category": "N1b",
-							"pathological_m_category": "M1d",
-							"pathological_stage_group": "Stage IS",
-							"specimen_collection_date": "2020-02-29",
-							"specimen_storage": "Cut slide",
-							"tumour_histological_type": "8962/1",
-							"specimen_anatomic_location": "C43.1",
-							"reference_pathology_confirmed_diagnosis": "Not done",
-							"reference_pathology_confirmed_tumour_presence": "Not done",
-							"tumour_grading_system": "Grading system for GISTs",
-							"tumour_grade": "GX",
-							"percent_tumour_cells_range": "0-19%",
-							"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
-							"specimen_processing": "Cryopreservation in dry ice (dead tissue)",
-							"specimen_laterality": "Left",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_14",
-									"specimen_tissue_source": "Urine",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Xenograft - derived from metastatic tumour",
-									"sample_type": "Total RNA"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_7",
-							"is_primary_treatment": "No",
-							"treatment_start_date": "2021-04",
-							"treatment_end_date": "2022-03",
-							"treatment_setting": "Mobilization",
-							"treatment_intent": "Curative",
-							"days_per_cycle": 3,
-							"number_of_cycles": 5,
-							"line_of_treatment": 3,
-							"status_of_treatment": "Other",
-							"treatment_type": [
-								"Chemotherapy",
-								"Hormonal therapy"
-							],
-							"response_to_treatment_criteria_method": "iRECIST",
-							"response_to_treatment": "Immune complete response (iCR)",
-							"chemotherapies": [],
-							"hormone_therapies": [
-								{
-									"hormone_drug_dose_units": "g/m2",
-									"drug_reference_database": "PubChem",
-									"drug_name": "goserelin",
-									"drug_reference_identifier": "557845",
-									"prescribed_cumulative_drug_dose": 187,
-									"actual_cumulative_drug_dose": 133
-								}
-							],
-							"immunotherapies": [],
-
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_13",
-									"date_of_followup": "2022-10",
-									"disease_status_at_followup": "Stable",
-									"relapse_type": "Progression (liquid tumours)",
-									"date_of_relapse": "2021-12",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C09",
-									"recurrence_tumour_staging_system": "AJCC 7th edition",
-									"recurrence_t_category": "T1b(s)",
-									"recurrence_n_category": "N1a(sn)",
-									"recurrence_m_category": "M1b(1)",
-									"recurrence_stage_group": "Stage IAB",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						},
-						{
-							"submitter_treatment_id": "TREATMENT_8",
-							"is_primary_treatment": "Unknown",
-							"treatment_start_date": "2021-08",
-							"treatment_end_date": "2022-01",
-							"treatment_setting": "Induction",
-							"treatment_intent": "Palliative",
-							"days_per_cycle": 3,
-							"number_of_cycles": 5,
-							"line_of_treatment": 1,
-							"status_of_treatment": "Unknown",
-							"treatment_type": [
-								"Hormonal therapy"
-							],
-							"response_to_treatment_criteria_method": "RECIST 1.1",
-							"response_to_treatment": "Immune confirmed progressive disease (iCPD)",
-							"chemotherapies": [],
-							"hormone_therapies": [
-								{
-									"hormone_drug_dose_units": "IU/m2",
-									"drug_reference_database": "RxNorm",
-									"drug_name": "exemestane",
-									"drug_reference_identifier": "223986",
-									"prescribed_cumulative_drug_dose": 124,
-									"actual_cumulative_drug_dose": 134
-								}
-							],
-							"immunotherapies": [],
-
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_14",
-									"date_of_followup": "2022-11",
-									"disease_status_at_followup": "Relapse or recurrence",
-									"relapse_type": "Biochemical progression",
-									"date_of_relapse": "2022-02",
-									"method_of_progression_status": [
-										"Assessment of symptom control (procedure)"
-									],
-									"anatomic_site_progression_or_recurrence": "C03",
-									"recurrence_tumour_staging_system": "AJCC 6th edition",
-									"recurrence_t_category": "T3d",
-									"recurrence_n_category": "N2a",
-									"recurrence_m_category": "M1b",
-									"recurrence_stage_group": "Stage IS",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				}
-			],
-			"comorbidities": [
-				{
-					"prior_malignancy": "Yes",
-					"laterality_of_prior_malignancy": "Right",
-					"comorbidity_type_code": "C34.9",
-					"comorbidity_treatment_status": "Unknown",
-					"comorbidity_treatment": "Ablation",
-					"age_at_comorbidity_diagnosis": 44
-				},
-				{
-					"prior_malignancy": "Yes",
-					"laterality_of_prior_malignancy": "Unilateral, Side not specified",
-					"comorbidity_type_code": "C43.9",
-					"comorbidity_treatment_status": "Yes",
-					"comorbidity_treatment": "Hormonal therapy",
-					"age_at_comorbidity_diagnosis": 46
-				},
-				{
-					"prior_malignancy": "No",
-					"laterality_of_prior_malignancy": "Unilateral, Side not specified",
-					"comorbidity_type_code": "C02.1",
-					"comorbidity_treatment_status": "Yes",
-					"comorbidity_treatment": "Endoscopic therapy",
-					"age_at_comorbidity_diagnosis": 40
-				}
-			],
-			"exposures": [
-				{
-					"tobacco_smoking_status": "Current smoker",
-					"tobacco_type": [
-						"Unknown",
-						"Electronic cigarettes",
-						"Not applicable"
-					],
-					"pack_years_smoked": 280.0
-				},
-				{
-					"tobacco_smoking_status": "Not applicable",
-					"tobacco_type": [
-						"Chewing Tobacco",
-						"Pipe",
-						"Not applicable"
-					],
-					"pack_years_smoked": 138.0
-				},
-				{
-					"tobacco_smoking_status": "Not applicable",
-					"tobacco_type": [
-						"Cigar",
-						"Waterpipe",
-						"Electronic cigarettes"
-					],
-					"pack_years_smoked": 141.0
-				}
-			],
-			"biomarkers": [],
-			"followups": []
-		},
-		{
-			"submitter_donor_id": "DONOR_10",
-			"program_id": "SYNTHETIC-2",
-			"lost_to_followup_after_clinical_event_identifier": "",
-			"lost_to_followup_reason": "Not applicable",
-			"date_alive_after_lost_to_followup": "2022-03",
-			"is_deceased": true,
-			"cause_of_death": "Unknown",
-			"date_of_birth": "1987-09",
-			"date_of_death": "2015-09",
-			"gender": "Woman",
-			"sex_at_birth": "Other",
-			"primary_site": [
-				"Esophagus",
-				"Base of tongue",
-				"Nasal cavity and middle ear"
-			],
-			"primary_diagnoses": [
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_16",
-					"date_of_diagnosis": "2019-10",
-					"cancer_type_code": "C43.9",
-					"basis_of_diagnosis": "Histology of a primary tumour",
-					"lymph_nodes_examined_status": "No lymph nodes found in resected specimen",
-					"lymph_nodes_examined_method": "Physical palpation of patient",
-					"number_lymph_nodes_positive": 10,
-					"clinical_tumour_staging_system": "Binet staging system",
-					"clinical_t_category": "T4b",
-					"clinical_n_category": "N0(mol-)",
-					"clinical_m_category": "M1a(1)",
-					"clinical_stage_group": "Stage IBS",
-					"laterality": "Bilateral",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_22",
-							"pathological_tumour_staging_system": "Durie-Salmon staging system",
-							"pathological_t_category": "T3e",
-							"pathological_n_category": "N0(mol+)",
-							"pathological_m_category": "M0",
-							"pathological_stage_group": "Stage IIBES",
-							"specimen_collection_date": "2021-04-20",
-							"specimen_storage": "Paraffin block",
-							"tumour_histological_type": "8124/9",
-							"specimen_anatomic_location": "C43.9",
-							"reference_pathology_confirmed_diagnosis": "Unknown",
-							"reference_pathology_confirmed_tumour_presence": "Not done",
-							"tumour_grading_system": "Scarff-Bloom-Richardson grading system",
-							"tumour_grade": "Grade Group 3",
-							"percent_tumour_cells_range": "20-50%",
-							"percent_tumour_cells_measurement_method": "Image analysis",
-							"specimen_processing": "Other",
-							"specimen_laterality": "Right",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_28",
-									"specimen_tissue_source": "Venous blood",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Primary tumour - adjacent to normal",
-									"sample_type": "Total RNA"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_22",
-							"is_primary_treatment": "Yes",
-							"treatment_start_date": "2021-10",
-							"treatment_end_date": "2022-07",
-							"treatment_setting": "Neoadjuvant",
-							"treatment_intent": "Diagnostic",
-							"days_per_cycle": 6,
-							"number_of_cycles": 4,
-							"line_of_treatment": 1,
-							"status_of_treatment": "Treatment incomplete due to technical or organizational problems",
-							"treatment_type": [
-								"Surgery"
-							],
-							"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
-							"response_to_treatment": "Partial response",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-							"surgery": {
-								"surgery_type": "Pneumonectomy",
-								"surgery_site": "C14",
-								"surgery_location": "Primary",
-								"tumour_focality": "Unifocal",
-								"residual_tumour_classification": "R2",
-								"margin_types_involved": [
-									"Unknown"
+{
+	"donors": [
+			{
+				"submitter_donor_id": "DONOR_1",
+				"program_id": "SYNTHETIC-2",
+				"lost_to_followup_after_clinical_event_identifier": "",
+				"lost_to_followup_reason": "Not applicable",
+				"date_alive_after_lost_to_followup": "2022-02",
+				"is_deceased": true,
+				"cause_of_death": "Unknown",
+				"date_of_birth": "1961-07",
+				"date_of_death": "2009-07",
+				"gender": "Woman",
+				"sex_at_birth": "Unknown",
+				"primary_site": [
+					"Corpus uteri",
+					"Anus and anal canal"
+				],
+				"primary_diagnoses": [
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_1",
+						"date_of_diagnosis": "2019-06",
+						"cancer_type_code": "C02.1",
+						"basis_of_diagnosis": "Histology of a metastasis",
+						"lymph_nodes_examined_status": "No lymph nodes found in resected specimen",
+						"lymph_nodes_examined_method": "Lymph node dissection/pathological exam",
+						"number_lymph_nodes_positive": 10,
+						"clinical_tumour_staging_system": "FIGO staging system",
+						"clinical_t_category": "TX",
+						"clinical_n_category": "N1mi",
+						"clinical_m_category": "M1a",
+						"clinical_stage_group": "Stage IIIAES",
+						"laterality": "Unilateral, side not specified",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_1",
+								"pathological_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
+								"pathological_t_category": "T4a",
+								"pathological_n_category": "N1",
+								"pathological_m_category": "MX",
+								"pathological_stage_group": "Stage IIAE",
+								"specimen_collection_date": "2021-06-01",
+								"specimen_storage": "Frozen in liquid nitrogen",
+								"tumour_histological_type": "8820/3",
+								"specimen_anatomic_location": "C67.6",
+								"reference_pathology_confirmed_diagnosis": "Not done",
+								"reference_pathology_confirmed_tumour_presence": "Unknown",
+								"tumour_grading_system": "Grading system for GISTs",
+								"tumour_grade": "Grade 3",
+								"percent_tumour_cells_range": "0-19%",
+								"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
+								"specimen_processing": "Cryopreservation in liquid nitrogen (dead tissue)",
+								"specimen_laterality": "Right",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_1",
+										"specimen_tissue_source": "Pleural fluid",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Cell line - derived from normal",
+										"sample_type": "Other DNA enrichments"
+									},
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_2",
+										"specimen_tissue_source": "Seminal fluid",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Xenograft - derived from metastatic tumour",
+										"sample_type": "rRNA-depleted RNA"
+									},
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_3",
+										"specimen_tissue_source": "Seminal fluid",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Primary tumour",
+										"sample_type": "Protein"
+									}
 								],
-								"margin_types_not_involved": [
-									"Circumferential resection margin"
+								"biomarkers": [
+									{
+										"er_status": "Cannot be determined",
+										"pr_status": "Not applicable",
+										"her2_ihc_status": "Equivocal",
+										"her2_ish_status": "Unknown",
+										"hpv_ihc_status": "Not applicable",
+										"hpv_pcr_status": "Unknown",
+										"hpv_strain": [
+											"HPV68"
+										],
+										"test_interval": 7,
+										"psa_level": 343,
+										"ca125": 58,
+										"cea": 9,
+										"er_percent_positive": 19.1,
+										"pr_percent_positive": 17.9
+									},
+									{
+										"er_status": "Unknown",
+										"pr_status": "Not applicable",
+										"her2_ihc_status": "Equivocal",
+										"her2_ish_status": "Positive",
+										"hpv_ihc_status": "Not applicable",
+										"hpv_pcr_status": "Negative",
+										"hpv_strain": [
+											"HPV18"
+										],
+										"test_interval": 6,
+										"psa_level": 399,
+										"ca125": 73,
+										"cea": 8,
+										"er_percent_positive": 45.5,
+										"pr_percent_positive": 52.5
+									}
+								]
+							},
+							{
+								"submitter_specimen_id": "SPECIMEN_2",
+								"pathological_tumour_staging_system": "AJCC 7th edition",
+								"pathological_t_category": "T4a",
+								"pathological_n_category": "N2a",
+								"pathological_m_category": "M1d",
+								"pathological_stage_group": "Stage IIIC2",
+								"specimen_collection_date": "2020-06-30",
+								"specimen_storage": "Not Applicable",
+								"tumour_histological_type": "8980/2",
+								"specimen_anatomic_location": "C43.9",
+								"reference_pathology_confirmed_diagnosis": "No",
+								"reference_pathology_confirmed_tumour_presence": "Unknown",
+								"tumour_grading_system": "IASLC grading system",
+								"tumour_grade": "Grade Group 5",
+								"percent_tumour_cells_range": "20-50%",
+								"percent_tumour_cells_measurement_method": "Unknown",
+								"specimen_processing": "Fresh",
+								"specimen_laterality": "Not applicable",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_4",
+										"specimen_tissue_source": "Hydrocele fluid",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Normal",
+										"sample_type": "Other DNA enrichments"
+									},
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_5",
+										"specimen_tissue_source": "Sputum",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Normal",
+										"sample_type": "Total RNA"
+									},
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_6",
+										"specimen_tissue_source": "Cervical mucus",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Recurrent tumour",
+										"sample_type": "Total DNA"
+									}
 								],
-								"margin_types_not_assessed": [
-									"Distal margin",
-									"Proximal margin"
+								"biomarkers": []
+							},
+							{
+								"submitter_specimen_id": "SPECIMEN_3",
+								"pathological_tumour_staging_system": "AJCC 7th edition",
+								"pathological_t_category": "T1a2",
+								"pathological_n_category": "N2c",
+								"pathological_m_category": "M1a(1)",
+								"pathological_stage_group": "Stage IIBE",
+								"specimen_collection_date": "2020-10-26",
+								"specimen_storage": "Frozen in vapour phase",
+								"tumour_histological_type": "8209/3",
+								"specimen_anatomic_location": "C43.9",
+								"reference_pathology_confirmed_diagnosis": "Not done",
+								"reference_pathology_confirmed_tumour_presence": "Yes",
+								"tumour_grading_system": "Nuclear grading system for DCIS",
+								"tumour_grade": "G3",
+								"percent_tumour_cells_range": "51-100%",
+								"percent_tumour_cells_measurement_method": "Image analysis",
+								"specimen_processing": "Formalin fixed - unbuffered",
+								"specimen_laterality": "Left",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_7",
+										"specimen_tissue_source": "Vitreous fluid",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Metastatic tumour - metastasis to distant location",
+										"sample_type": "polyA+ RNA"
+									},
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_8",
+										"specimen_tissue_source": "Seminal fluid",
+										"tumour_normal_designation": "Normal",
+										"specimen_type": "Normal - tissue adjacent to primary tumour",
+										"sample_type": "Total DNA"
+									}
 								],
-								"lymphovascular_invasion": "Unknown",
-								"perineural_invasion": "Unknown",
-								"tumour_length": 3,
-								"tumour_width": 5,
-								"greatest_dimension_tumour": 5,
-								"submitter_specimen_id": null
-							},
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_28",
-									"date_of_followup": "2022-08",
-									"disease_status_at_followup": "Loco-regional progression",
-									"relapse_type": "Local recurrence",
-									"date_of_relapse": "2022-06",
-									"method_of_progression_status": [
-										"Histopathology test (procedure)",
-										"Physical examination procedure (procedure)"
-									],
-									"anatomic_site_progression_or_recurrence": "C10",
-									"recurrence_tumour_staging_system": "AJCC 6th edition",
-									"recurrence_t_category": "T3",
-									"recurrence_n_category": "N0(i+)",
-									"recurrence_m_category": "M1c(0)",
-									"recurrence_stage_group": "Stage 4",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				}
-			],
-			"comorbidities": [],
-			"exposures": [],
-			"biomarkers": [],
-			"followups": []
-		},
-		{
-			"submitter_donor_id": "DONOR_2",
-			"program_id": "SYNTHETIC-2",
-			"lost_to_followup_after_clinical_event_identifier": "",
-			"lost_to_followup_reason": "Discharged to palliative care",
-			"date_alive_after_lost_to_followup": "2022-10",
-			"is_deceased": false,
-			"cause_of_death": "Died of other reasons",
-			"date_of_birth": "1994-06",
-			"date_of_death": null,
-			"gender": "Man",
-			"sex_at_birth": "Male",
-			"primary_site": [
-				"Bronchus and lung",
-				"Larynx",
-				"Pancreas"
-			],
-			"primary_diagnoses": [
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_4",
-					"date_of_diagnosis": "2019-09",
-					"cancer_type_code": "C04.9",
-					"basis_of_diagnosis": "Clinical investigation",
-					"lymph_nodes_examined_status": "Not applicable",
-					"lymph_nodes_examined_method": "Physical palpation of patient",
-					"number_lymph_nodes_positive": 8,
-					"clinical_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
-					"clinical_t_category": "T4a",
-					"clinical_n_category": "N0",
-					"clinical_m_category": "M1b(1)",
-					"clinical_stage_group": "Stage IIA1",
-					"laterality": "Unknown",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_10",
-							"pathological_tumour_staging_system": "Rai staging system",
-							"pathological_t_category": "TX",
-							"pathological_n_category": "N0",
-							"pathological_m_category": "M1d(1)",
-							"pathological_stage_group": "Stage 1",
-							"specimen_collection_date": "2020-12-26",
-							"specimen_storage": "Cut slide",
-							"tumour_histological_type": "8630/9",
-							"specimen_anatomic_location": "C34.9",
-							"reference_pathology_confirmed_diagnosis": "Unknown",
-							"reference_pathology_confirmed_tumour_presence": "Yes",
-							"tumour_grading_system": "Nuclear grading system for DCIS",
-							"tumour_grade": "High grade",
-							"percent_tumour_cells_range": "51-100%",
-							"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
-							"specimen_processing": "Cryopreservation of live cells in liquid nitrogen",
-							"specimen_laterality": "Right",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_16",
-									"specimen_tissue_source": "Bile",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Metastatic tumour - additional metastatic",
-									"sample_type": "polyA+ RNA"
-								}
-							],
-							"biomarkers": []
-						},
-						{
-							"submitter_specimen_id": "SPECIMEN_9",
-							"pathological_tumour_staging_system": "AJCC 6th edition",
-							"pathological_t_category": "T4b",
-							"pathological_n_category": "N0a (biopsy)",
-							"pathological_m_category": "M1a(0)",
-							"pathological_stage_group": "Stage IIID",
-							"specimen_collection_date": "2021-07-29",
-							"specimen_storage": "RNA later frozen",
-							"tumour_histological_type": "8973/2",
-							"specimen_anatomic_location": "C43.9",
-							"reference_pathology_confirmed_diagnosis": "Unknown",
-							"reference_pathology_confirmed_tumour_presence": "Unknown",
-							"tumour_grading_system": "FNCLCC grading system",
-							"tumour_grade": "Grade 2",
-							"percent_tumour_cells_range": "20-50%",
-							"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
-							"specimen_processing": "Formalin fixed - unbuffered",
-							"specimen_laterality": "Not applicable",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_15",
-									"specimen_tissue_source": "Blood derived - peripheral blood",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Recurrent tumour",
-									"sample_type": "Total RNA"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_10",
-							"is_primary_treatment": "Unknown",
-							"treatment_start_date": "2021-08",
-							"treatment_end_date": "2022-10",
-							"treatment_setting": "Salvage",
-							"treatment_intent": "Forensic",
-							"days_per_cycle": 1,
-							"number_of_cycles": 5,
-							"line_of_treatment": 5,
-							"status_of_treatment": "Not applicable",
-							"treatment_type": [
-								"Radiation therapy",
-								"Bone marrow transplant",
-								"No treatment"
-							],
-							"response_to_treatment_criteria_method": "Physician Assessed Response Criteria",
-							"response_to_treatment": "No evidence of disease (NED)",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-							"radiation": {
-								"radiation_therapy_modality": "Teleradiotherapy protons (procedure)",
-								"radiation_therapy_type": "Internal",
-								"anatomical_site_irradiated": "Finger (Including Thumbs)",
-								"radiation_therapy_fractions": 30,
-								"radiation_therapy_dosage": 66,
-								"radiation_boost": true,
-								"reference_radiation_treatment_id": "REFERENCE_RADIATION_TREATMENT_2"
-							},
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_1",
+								"is_primary_treatment": "Unknown",
+								"treatment_start_date": "2021-01",
+								"treatment_end_date": "2022-08",
+								"treatment_setting": "Mobilization",
+								"treatment_intent": "Screening",
+								"days_per_cycle": 4,
+								"number_of_cycles": 5,
+								"line_of_treatment": 5,
+								"status_of_treatment": "Other",
+								"treatment_type": [
+									"Bone marrow transplant",
+									"Photodynamic therapy"
+								],
+								"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
+								"response_to_treatment": "Complete response",
+								"chemotherapies": [
+									{
+										"chemotherapy_drug_dose_units": "ug/m2",
+										"drug_reference_database": "NCI Thesaurus",
+										"drug_name": "LEUCOVORIN",
+										"drug_reference_identifier": "876459",
+										"prescribed_cumulative_drug_dose": 4600,
+										"actual_cumulative_drug_dose": 66
+									},
+									{
+										"chemotherapy_drug_dose_units": "ug/m2",
+										"drug_reference_database": "PubChem",
+										"drug_name": "FLUOROURACIL",
+										"drug_reference_identifier": "87354",
+										"prescribed_cumulative_drug_dose": 150,
+										"actual_cumulative_drug_dose": 94
+									},
+									{
+										"chemotherapy_drug_dose_units": "mg/m2",
+										"drug_reference_database": "PubChem",
+										"drug_name": "LIPOSOMAL IRINOTECAN",
+										"drug_reference_identifier": "7365837",
+										"prescribed_cumulative_drug_dose": 320,
+										"actual_cumulative_drug_dose": 60
+									}
+								],
+								"hormone_therapies": [],
+								"immunotherapies": [],
 
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_16",
-									"date_of_followup": "2022-09",
-									"disease_status_at_followup": "Loco-regional progression",
-									"relapse_type": "Distant recurrence/metastasis",
-									"date_of_relapse": "2022-10",
-									"method_of_progression_status": [
-										"Laboratory data interpretation (procedure)",
-										"Histopathology test (procedure)"
-									],
-									"anatomic_site_progression_or_recurrence": "C14",
-									"recurrence_tumour_staging_system": "St Jude staging system",
-									"recurrence_t_category": "T2(m)",
-									"recurrence_n_category": "N0b",
-									"recurrence_m_category": "M1c(1)",
-									"recurrence_stage_group": "Stage IB",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						},
-						{
-							"submitter_treatment_id": "TREATMENT_9",
-							"is_primary_treatment": "Unknown",
-							"treatment_start_date": "2021-07",
-							"treatment_end_date": "2022-11",
-							"treatment_setting": "Maintenance",
-							"treatment_intent": "Supportive",
-							"days_per_cycle": 7,
-							"number_of_cycles": 5,
-							"line_of_treatment": 4,
-							"status_of_treatment": "Treatment incomplete due to technical or organizational problems",
-							"treatment_type": [
-								"Surgery"
-							],
-							"response_to_treatment_criteria_method": "RECIST 1.1",
-							"response_to_treatment": "Immune confirmed progressive disease (iCPD)",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-							"radiation": {
-								"radiation_therapy_modality": "Teleradiotherapy neutrons (procedure)",
-								"radiation_therapy_type": "Internal",
-								"anatomical_site_irradiated": "Left Maxilla",
-								"radiation_therapy_fractions": 30,
-								"radiation_therapy_dosage": 66,
-								"radiation_boost": true,
-								"reference_radiation_treatment_id": "REFERENCE_RADIATION_TREATMENT_1"
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_1",
+										"date_of_followup": "2022-08",
+										"disease_status_at_followup": "Loco-regional progression",
+										"relapse_type": "Distant recurrence/metastasis",
+										"date_of_relapse": "2022-01",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C06",
+										"recurrence_tumour_staging_system": "SEER staging system",
+										"recurrence_t_category": "T2(m)",
+										"recurrence_n_category": "N2c",
+										"recurrence_m_category": "M1b(1)",
+										"recurrence_stage_group": "Stage IIBES",
+										"biomarkers": [
+											{
+												"er_status": "Negative",
+												"pr_status": "Unknown",
+												"her2_ihc_status": "Negative",
+												"her2_ish_status": "Equivocal",
+												"hpv_ihc_status": "Negative",
+												"hpv_pcr_status": "Positive",
+												"hpv_strain": [
+													"HPV31",
+													"HPV68"
+												],
+												"test_interval": 5,
+												"psa_level": 318,
+												"ca125": 78,
+												"cea": 13,
+												"er_percent_positive": 12.4,
+												"pr_percent_positive": 11.0
+											},
+											{
+												"er_status": "Cannot be determined",
+												"pr_status": "Unknown",
+												"her2_ihc_status": "Equivocal",
+												"her2_ish_status": "Negative",
+												"hpv_ihc_status": "Not applicable",
+												"hpv_pcr_status": "Negative",
+												"hpv_strain": [
+													"HPV35"
+												],
+												"test_interval": 4,
+												"psa_level": 379,
+												"ca125": 106,
+												"cea": 4,
+												"er_percent_positive": 18.3,
+												"pr_percent_positive": 65.2
+											},
+											{
+												"er_status": "Cannot be determined",
+												"pr_status": "Not applicable",
+												"her2_ihc_status": "Not applicable",
+												"her2_ish_status": "Cannot be determined",
+												"hpv_ihc_status": "Cannot be determined",
+												"hpv_pcr_status": "Unknown",
+												"hpv_strain": [
+													"HPV18"
+												],
+												"test_interval": 8,
+												"psa_level": 328,
+												"ca125": 104,
+												"cea": 13,
+												"er_percent_positive": 21.0,
+												"pr_percent_positive": 32.7
+											}
+										]
+									},
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_2",
+										"date_of_followup": "2022-11",
+										"disease_status_at_followup": "Loco-regional progression",
+										"relapse_type": "Biochemical progression",
+										"date_of_relapse": "2022-05",
+										"method_of_progression_status": [
+											"Imaging (procedure)",
+											"Laboratory data interpretation (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C05",
+										"recurrence_tumour_staging_system": "Lugano staging system",
+										"recurrence_t_category": "T1d",
+										"recurrence_n_category": "N1mi",
+										"recurrence_m_category": "M1a(0)",
+										"recurrence_stage_group": "Stage IVBS",
+										"biomarkers": [
+											{
+												"er_status": "Positive",
+												"pr_status": "Positive",
+												"her2_ihc_status": "Not applicable",
+												"her2_ish_status": "Equivocal",
+												"hpv_ihc_status": "Unknown",
+												"hpv_pcr_status": "Not applicable",
+												"hpv_strain": [
+													"HPV73"
+												],
+												"test_interval": 5,
+												"psa_level": 351,
+												"ca125": 81,
+												"cea": 7,
+												"er_percent_positive": 97.8,
+												"pr_percent_positive": 32.9
+											},
+											{
+												"er_status": "Not applicable",
+												"pr_status": "Cannot be determined",
+												"her2_ihc_status": "Positive",
+												"her2_ish_status": "Unknown",
+												"hpv_ihc_status": "Cannot be determined",
+												"hpv_pcr_status": "Positive",
+												"hpv_strain": [
+													"HPV68"
+												],
+												"test_interval": 8,
+												"psa_level": 326,
+												"ca125": 96,
+												"cea": 11,
+												"er_percent_positive": 13.7,
+												"pr_percent_positive": 85.4
+											},
+											{
+												"er_status": "Unknown",
+												"pr_status": "Not applicable",
+												"her2_ihc_status": "Equivocal",
+												"her2_ish_status": "Unknown",
+												"hpv_ihc_status": "Negative",
+												"hpv_pcr_status": "Unknown",
+												"hpv_strain": [
+													"HPV68",
+													"HPV18"
+												],
+												"test_interval": 7,
+												"psa_level": 212,
+												"ca125": 54,
+												"cea": 8,
+												"er_percent_positive": 5.3,
+												"pr_percent_positive": 74.3
+											}
+										]
+									},
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_3",
+										"date_of_followup": "2022-10",
+										"disease_status_at_followup": "No evidence of disease",
+										"relapse_type": "Local recurrence and distant metastasis",
+										"date_of_relapse": "2022-07",
+										"method_of_progression_status": [
+											"Histopathology test (procedure)",
+											"Assessment of symptom control (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C18",
+										"recurrence_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
+										"recurrence_t_category": "T1b2",
+										"recurrence_n_category": "N1b",
+										"recurrence_m_category": "M0",
+										"recurrence_stage_group": "Stage IIEA",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": [
+									{
+										"er_status": "Cannot be determined",
+										"pr_status": "Not applicable",
+										"her2_ihc_status": "Equivocal",
+										"her2_ish_status": "Unknown",
+										"hpv_ihc_status": "Not applicable",
+										"hpv_pcr_status": "Unknown",
+										"hpv_strain": [
+											"HPV68"
+										],
+										"test_interval": 7,
+										"psa_level": 343,
+										"ca125": 58,
+										"cea": 9,
+										"er_percent_positive": 19.1,
+										"pr_percent_positive": 17.9
+									},
+									{
+										"er_status": "Unknown",
+										"pr_status": "Not applicable",
+										"her2_ihc_status": "Equivocal",
+										"her2_ish_status": "Positive",
+										"hpv_ihc_status": "Not applicable",
+										"hpv_pcr_status": "Negative",
+										"hpv_strain": [
+											"HPV18"
+										],
+										"test_interval": 6,
+										"psa_level": 399,
+										"ca125": 73,
+										"cea": 8,
+										"er_percent_positive": 45.5,
+										"pr_percent_positive": 52.5
+									}
+								]
 							},
+							{
+								"submitter_treatment_id": "TREATMENT_2",
+								"is_primary_treatment": "Yes",
+								"treatment_start_date": "2021-12",
+								"treatment_end_date": "2022-10",
+								"treatment_setting": "Conditioning",
+								"treatment_intent": "Palliative",
+								"days_per_cycle": 4,
+								"number_of_cycles": 3,
+								"line_of_treatment": 3,
+								"status_of_treatment": "Treatment stopped due to acute toxicity",
+								"treatment_type": [
+									"Radiation therapy",
+									"Other targeting molecular therapy",
+									"Hormonal therapy"
+								],
+								"response_to_treatment_criteria_method": "Cheson CLL 2012 Oncology Response Criteria",
+								"response_to_treatment": "Major response",
+								"chemotherapies": [
+									{
+										"chemotherapy_drug_dose_units": "IU/kg",
+										"drug_reference_database": "PubChem",
+										"drug_name": "NIVOLUMAB",
+										"drug_reference_identifier": "7365837",
+										"prescribed_cumulative_drug_dose": 150,
+										"actual_cumulative_drug_dose": 111
+									},
+									{
+										"chemotherapy_drug_dose_units": "mg/m2",
+										"drug_reference_database": "NCI Thesaurus",
+										"drug_name": "FLUOROURACIL",
+										"drug_reference_identifier": "836754",
+										"prescribed_cumulative_drug_dose": 4600,
+										"actual_cumulative_drug_dose": 90
+									}
+								],
+								"hormone_therapies": [],
+								"immunotherapies": [],
 
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_15",
-									"date_of_followup": "2022-08",
-									"disease_status_at_followup": "Partial remission",
-									"relapse_type": "Biochemical progression",
-									"date_of_relapse": "2022-02",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C16",
-									"recurrence_tumour_staging_system": "Durie-Salmon staging system",
-									"recurrence_t_category": "T2a",
-									"recurrence_n_category": "N2",
-									"recurrence_m_category": "M1c",
-									"recurrence_stage_group": "Stage A",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [
-						{
-							"er_status": "Cannot be determined",
-							"pr_status": "Negative",
-							"her2_ihc_status": "Unknown",
-							"her2_ish_status": "Not applicable",
-							"hpv_ihc_status": "Not applicable",
-							"hpv_pcr_status": "Positive",
-							"hpv_strain": [
-								"HPV35"
-							],
-							"test_interval": 6,
-							"psa_level": 304,
-							"ca125": 111,
-							"cea": 9,
-							"er_percent_positive": 1.3,
-							"pr_percent_positive": 15.1
-						}
-					],
-					"followups": []
-				},
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_5",
-					"date_of_diagnosis": "2019-02",
-					"cancer_type_code": "C02.1",
-					"basis_of_diagnosis": "Clinical",
-					"lymph_nodes_examined_status": "Yes",
-					"lymph_nodes_examined_method": "Physical palpation of patient",
-					"number_lymph_nodes_positive": 15,
-					"clinical_tumour_staging_system": "Ann Arbor staging system",
-					"clinical_t_category": "T4",
-					"clinical_n_category": "N3b",
-					"clinical_m_category": "M1d(1)",
-					"clinical_stage_group": "Stage IAS",
-					"laterality": "Left",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_11",
-							"pathological_tumour_staging_system": "AJCC 6th edition",
-							"pathological_t_category": "T1b(s)",
-							"pathological_n_category": "N3c",
-							"pathological_m_category": "M1",
-							"pathological_stage_group": "Stage II bulky",
-							"specimen_collection_date": "2021-10-26",
-							"specimen_storage": "Frozen in liquid nitrogen",
-							"tumour_histological_type": "8980/9",
-							"specimen_anatomic_location": "C43.1",
-							"reference_pathology_confirmed_diagnosis": "Not done",
-							"reference_pathology_confirmed_tumour_presence": "Unknown",
-							"tumour_grading_system": "Gleason grade group system",
-							"tumour_grade": "Grade 4",
-							"percent_tumour_cells_range": "0-19%",
-							"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
-							"specimen_processing": "Fresh",
-							"specimen_laterality": "Not applicable",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_17",
-									"specimen_tissue_source": "Pancreatic fluid",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Metastatic tumour - additional metastatic",
-									"sample_type": "Total DNA"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_11",
-							"is_primary_treatment": "Yes",
-							"treatment_start_date": "2021-11",
-							"treatment_end_date": "2022-06",
-							"treatment_setting": "Induction",
-							"treatment_intent": "Curative",
-							"days_per_cycle": 4,
-							"number_of_cycles": 5,
-							"line_of_treatment": 1,
-							"status_of_treatment": "Treatment stopped due to acute toxicity",
-							"treatment_type": [
-								"Hormonal therapy",
-								"Other targeting molecular therapy",
-								"Surgery"
-							],
-							"response_to_treatment_criteria_method": "RECIST 1.1",
-							"response_to_treatment": "Physician assessed stable disease",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-							"radiation": {
-								"radiation_therapy_modality": "Teleradiotherapy neutrons (procedure)",
-								"radiation_therapy_type": "External",
-								"anatomical_site_irradiated": "Left Scapula",
-								"radiation_therapy_fractions": 35,
-								"radiation_therapy_dosage": 70,
-								"radiation_boost": true,
-								"reference_radiation_treatment_id": "REFERENCE_RADIATION_TREATMENT_3"
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_4",
+										"date_of_followup": "2022-11",
+										"disease_status_at_followup": "Distant progression",
+										"relapse_type": "Progression (liquid tumours)",
+										"date_of_relapse": "2021-12",
+										"method_of_progression_status": [
+											"Tumor marker measurement (procedure)",
+											"Physical examination procedure (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C10",
+										"recurrence_tumour_staging_system": "Rai staging system",
+										"recurrence_t_category": "T2b",
+										"recurrence_n_category": "N2mi",
+										"recurrence_m_category": "M1d",
+										"recurrence_stage_group": "Stage IIIS",
+										"biomarkers": []
+									},
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_5",
+										"date_of_followup": "2022-11",
+										"disease_status_at_followup": "Distant progression",
+										"relapse_type": "Progression (liquid tumours)",
+										"date_of_relapse": "2022-05",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C08",
+										"recurrence_tumour_staging_system": "AJCC 6th edition",
+										"recurrence_t_category": "T2a1",
+										"recurrence_n_category": "N0b",
+										"recurrence_m_category": "M1e",
+										"recurrence_stage_group": "Stage IIB",
+										"biomarkers": []
+									},
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_6",
+										"date_of_followup": "2022-08",
+										"disease_status_at_followup": "No evidence of disease",
+										"relapse_type": "Local recurrence and distant metastasis",
+										"date_of_relapse": "2022-10",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C13",
+										"recurrence_tumour_staging_system": "Revised International staging system (RISS)",
+										"recurrence_t_category": "T2(m)",
+										"recurrence_n_category": "N1a",
+										"recurrence_m_category": "M1",
+										"recurrence_stage_group": "Stage 0is",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": [
+									{
+										"er_status": "Positive",
+										"pr_status": "Unknown",
+										"her2_ihc_status": "Cannot be determined",
+										"her2_ish_status": "Not applicable",
+										"hpv_ihc_status": "Not applicable",
+										"hpv_pcr_status": "Negative",
+										"hpv_strain": [
+											"HPV51"
+										],
+										"test_interval": 7,
+										"psa_level": 207,
+										"ca125": 112,
+										"cea": 9,
+										"er_percent_positive": 73.5,
+										"pr_percent_positive": 72.8
+									},
+									{
+										"er_status": "Positive",
+										"pr_status": "Not applicable",
+										"her2_ihc_status": "Unknown",
+										"her2_ish_status": "Equivocal",
+										"hpv_ihc_status": "Not applicable",
+										"hpv_pcr_status": "Cannot be determined",
+										"hpv_strain": [
+											"HPV33"
+										],
+										"test_interval": 7,
+										"psa_level": 327,
+										"ca125": 103,
+										"cea": 8,
+										"er_percent_positive": 65.8,
+										"pr_percent_positive": 23.6
+									}
+								]
 							},
+							{
+								"submitter_treatment_id": "TREATMENT_3",
+								"is_primary_treatment": "Yes",
+								"treatment_start_date": "2021-09",
+								"treatment_end_date": "2022-10",
+								"treatment_setting": "Maintenance",
+								"treatment_intent": "Palliative",
+								"days_per_cycle": 4,
+								"number_of_cycles": 4,
+								"line_of_treatment": 3,
+								"status_of_treatment": "Physician decision (stopped or interrupted treatment)",
+								"treatment_type": [
+									"Bone marrow transplant",
+									"Other targeting molecular therapy",
+									"Radiation therapy"
+								],
+								"response_to_treatment_criteria_method": "iRECIST",
+								"response_to_treatment": "Morphologic leukemia-free state",
+								"chemotherapies": [
+									{
+										"chemotherapy_drug_dose_units": "mg/m2",
+										"drug_reference_database": "PubChem",
+										"drug_name": "GEMCITABINE",
+										"drug_reference_identifier": "836754",
+										"prescribed_cumulative_drug_dose": 780,
+										"actual_cumulative_drug_dose": 78
+									}
+								],
+								"hormone_therapies": [],
+								"immunotherapies": [],
 
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_17",
-									"date_of_followup": "2022-10",
-									"disease_status_at_followup": "Progression not otherwise specified",
-									"relapse_type": "Biochemical progression",
-									"date_of_relapse": "2022-01",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C14",
-									"recurrence_tumour_staging_system": "AJCC 6th edition",
-									"recurrence_t_category": "T1a2",
-									"recurrence_n_category": "N0(mol-)",
-									"recurrence_m_category": "M1a(1)",
-									"recurrence_stage_group": "Stage IVAES",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				},
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_6",
-					"date_of_diagnosis": "2019-10",
-					"cancer_type_code": "C43.1",
-					"basis_of_diagnosis": "Death certificate only",
-					"lymph_nodes_examined_status": "Not applicable",
-					"lymph_nodes_examined_method": "Physical palpation of patient",
-					"number_lymph_nodes_positive": 6,
-					"clinical_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
-					"clinical_t_category": "T2b",
-					"clinical_n_category": "N0a (biopsy)",
-					"clinical_m_category": "M0(i+)",
-					"clinical_stage_group": "Stage IIIC2",
-					"laterality": "Left",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_12",
-							"pathological_tumour_staging_system": "FIGO staging system",
-							"pathological_t_category": "Tis pd",
-							"pathological_n_category": "N1b",
-							"pathological_m_category": "M0(i+)",
-							"pathological_stage_group": "Stage IV",
-							"specimen_collection_date": "2020-07-07",
-							"specimen_storage": "Unknown",
-							"tumour_histological_type": "8962/1",
-							"specimen_anatomic_location": "C64.9",
-							"reference_pathology_confirmed_diagnosis": "Not done",
-							"reference_pathology_confirmed_tumour_presence": "No",
-							"tumour_grading_system": "Three-tier grading system",
-							"tumour_grade": "High",
-							"percent_tumour_cells_range": "0-19%",
-							"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
-							"specimen_processing": "Cryopreservation of live cells in liquid nitrogen",
-							"specimen_laterality": "Left",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_18",
-									"specimen_tissue_source": "Blood derived - bone marrow",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Cell line - derived from primary tumour",
-									"sample_type": "Other RNA fractions"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_12",
-							"is_primary_treatment": "Unknown",
-							"treatment_start_date": "2021-08",
-							"treatment_end_date": "2022-11",
-							"treatment_setting": "Mobilization",
-							"treatment_intent": "Forensic",
-							"days_per_cycle": 2,
-							"number_of_cycles": 5,
-							"line_of_treatment": 5,
-							"status_of_treatment": "Physician decision (stopped or interrupted treatment)",
-							"treatment_type": [
-								"Other targeting molecular therapy",
-								"Surgery"
-							],
-							"response_to_treatment_criteria_method": "Physician Assessed Response Criteria",
-							"response_to_treatment": "Partial remission",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-							"radiation": {
-								"radiation_therapy_modality": "Megavoltage radiation therapy using photons (procedure)",
-								"radiation_therapy_type": "Internal",
-								"anatomical_site_irradiated": "Right Adrenal",
-								"radiation_therapy_fractions": 30,
-								"radiation_therapy_dosage": 70,
-								"radiation_boost": false,
-								"reference_radiation_treatment_id": ""
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_7",
+										"date_of_followup": "2022-10",
+										"disease_status_at_followup": "No evidence of disease",
+										"relapse_type": "Biochemical progression",
+										"date_of_relapse": "2022-08",
+										"method_of_progression_status": [
+											"Laboratory data interpretation (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C12",
+										"recurrence_tumour_staging_system": "St Jude staging system",
+										"recurrence_t_category": "Tis pu",
+										"recurrence_n_category": "N1a(sn)",
+										"recurrence_m_category": "M1a(0)",
+										"recurrence_stage_group": "Stage IAB",
+										"biomarkers": []
+									},
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_8",
+										"date_of_followup": "2022-11",
+										"disease_status_at_followup": "Distant progression",
+										"relapse_type": "Progression (liquid tumours)",
+										"date_of_relapse": "2022-03",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C01",
+										"recurrence_tumour_staging_system": "SEER staging system",
+										"recurrence_t_category": "T1",
+										"recurrence_n_category": "N1b",
+										"recurrence_m_category": "M1b(1)",
+										"recurrence_stage_group": "Stage L1",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					},
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_2",
+						"date_of_diagnosis": "2019-03",
+						"cancer_type_code": "C02.2",
+						"basis_of_diagnosis": "Clinical investigation",
+						"lymph_nodes_examined_status": "Not applicable",
+						"lymph_nodes_examined_method": "Physical palpation of patient",
+						"number_lymph_nodes_positive": 5,
+						"clinical_tumour_staging_system": "International Neuroblastoma Staging System",
+						"clinical_t_category": "T1b",
+						"clinical_n_category": "N2",
+						"clinical_m_category": "M1d(1)",
+						"clinical_stage_group": "Stage Ms",
+						"laterality": "Left",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_4",
+								"pathological_tumour_staging_system": "SEER staging system",
+								"pathological_t_category": "T2a2",
+								"pathological_n_category": "N0(i+)",
+								"pathological_m_category": "M1b",
+								"pathological_stage_group": "Stage IAS",
+								"specimen_collection_date": "2021-05-10",
+								"specimen_storage": "Unknown",
+								"tumour_histological_type": "8980/9",
+								"specimen_anatomic_location": "C43.9",
+								"reference_pathology_confirmed_diagnosis": "Yes",
+								"reference_pathology_confirmed_tumour_presence": "Not done",
+								"tumour_grading_system": "Grading system for GISTs",
+								"tumour_grade": "Low",
+								"percent_tumour_cells_range": "0-19%",
+								"percent_tumour_cells_measurement_method": "Unknown",
+								"specimen_processing": "Cryopreservation of live cells in liquid nitrogen",
+								"specimen_laterality": "Right",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_10",
+										"specimen_tissue_source": "Pleural fluid",
+										"tumour_normal_designation": "Normal",
+										"specimen_type": "Metastatic tumour - metastasis local to lymph node",
+										"sample_type": "Total DNA"
+									},
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_9",
+										"specimen_tissue_source": "Buffy coat",
+										"tumour_normal_designation": "Normal",
+										"specimen_type": "Metastatic tumour - metastasis to distant location",
+										"sample_type": "rRNA-depleted RNA"
+									}
+								],
+								"biomarkers": []
 							},
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_18",
-									"date_of_followup": "2022-10",
-									"disease_status_at_followup": "Distant progression",
-									"relapse_type": "Progression (liquid tumours)",
-									"date_of_relapse": "2022-04",
-									"method_of_progression_status": [
-										"Histopathology test (procedure)",
-										"Imaging (procedure)"
-									],
-									"anatomic_site_progression_or_recurrence": "C20",
-									"recurrence_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
-									"recurrence_t_category": "T1c",
-									"recurrence_n_category": "N2b",
-									"recurrence_m_category": "M1c(0)",
-									"recurrence_stage_group": "Stage IIIC1",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				}
-			],
-			"comorbidities": [
-				{
-					"prior_malignancy": "Unknown",
-					"laterality_of_prior_malignancy": "Left",
-					"comorbidity_type_code": "C04.0",
-					"comorbidity_treatment_status": "Yes",
-					"comorbidity_treatment": "Other targeting molecular therapy",
-					"age_at_comorbidity_diagnosis": 57
-				},
-				{
-					"prior_malignancy": "No",
-					"laterality_of_prior_malignancy": "Midline",
-					"comorbidity_type_code": "C34.9",
-					"comorbidity_treatment_status": "Unknown",
-					"comorbidity_treatment": "Endoscopic therapy",
-					"age_at_comorbidity_diagnosis": 56
-				},
-				{
-					"prior_malignancy": "Yes",
-					"laterality_of_prior_malignancy": "Bilateral",
-					"comorbidity_type_code": "C50.9",
-					"comorbidity_treatment_status": "No",
-					"comorbidity_treatment": "Surgery",
-					"age_at_comorbidity_diagnosis": 53
-				}
-			],
-			"exposures": [
-				{
-					"tobacco_smoking_status": "Current reformed smoker for > 15 years",
-					"tobacco_type": [
-						"Cigarettes",
-						"Electronic cigarettes"
-					],
-					"pack_years_smoked": 90.0
-				},
-				{
-					"tobacco_smoking_status": "Current smoker",
-					"tobacco_type": [
-						"Cigarettes",
-						"Snuff"
-					],
-					"pack_years_smoked": 266.0
-				}
-			],
-			"biomarkers": [],
-			"followups": []
-		},
-		{
-			"submitter_donor_id": "DONOR_3",
-			"program_id": "SYNTHETIC-2",
-			"lost_to_followup_after_clinical_event_identifier": "",
-			"lost_to_followup_reason": "Discharged to palliative care",
-			"date_alive_after_lost_to_followup": "2022-01",
-			"is_deceased": true,
-			"cause_of_death": "Unknown",
-			"date_of_birth": "2005-08",
-			"date_of_death": "2011-08",
-			"gender": "Non-binary",
-			"sex_at_birth": "Female",
-			"primary_site": [
-				"Penis"
-			],
-			"primary_diagnoses": [
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_7",
-					"date_of_diagnosis": "2019-09",
-					"cancer_type_code": "C05.1",
-					"basis_of_diagnosis": "Death certificate only",
-					"lymph_nodes_examined_status": "Yes",
-					"lymph_nodes_examined_method": "Imaging",
-					"number_lymph_nodes_positive": 9,
-					"clinical_tumour_staging_system": "Ann Arbor staging system",
-					"clinical_t_category": "Tis(Paget)",
-					"clinical_n_category": "N3b",
-					"clinical_m_category": "M1a",
-					"clinical_stage_group": "Stage IIIES",
-					"laterality": "Right",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_13",
-							"pathological_tumour_staging_system": "AJCC 8th edition",
-							"pathological_t_category": "T1a(m)",
-							"pathological_n_category": "N3b",
-							"pathological_m_category": "M1b(0)",
-							"pathological_stage_group": "Stage A",
-							"specimen_collection_date": "2020-05-06",
-							"specimen_storage": "RNA later frozen",
-							"tumour_histological_type": "8124/9",
-							"specimen_anatomic_location": "C64.9",
-							"reference_pathology_confirmed_diagnosis": "Not done",
-							"reference_pathology_confirmed_tumour_presence": "Unknown",
-							"tumour_grading_system": "IASLC grading system",
-							"tumour_grade": "Grade Group 3",
-							"percent_tumour_cells_range": "20-50%",
-							"percent_tumour_cells_measurement_method": "Image analysis",
-							"specimen_processing": "Unknown",
-							"specimen_laterality": "Not applicable",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_19",
-									"specimen_tissue_source": "Solid tissue",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Metastatic tumour",
-									"sample_type": "Other RNA fractions"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_13",
-							"is_primary_treatment": "No",
-							"treatment_start_date": "2021-03",
-							"treatment_end_date": "2022-09",
-							"treatment_setting": "Mobilization",
-							"treatment_intent": "Guidance",
-							"days_per_cycle": 6,
-							"number_of_cycles": 5,
-							"line_of_treatment": 4,
-							"status_of_treatment": "Treatment incomplete due to technical or organizational problems",
-							"treatment_type": [
-								"Chemotherapy",
-								"Stem cell transplant",
-								"Bone marrow transplant"
-							],
-							"response_to_treatment_criteria_method": "Physician Assessed Response Criteria",
-							"response_to_treatment": "Partial remission",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-							"radiation": {
-								"radiation_therapy_modality": "Brachytherapy (procedure)",
-								"radiation_therapy_type": "External",
-								"anatomical_site_irradiated": "Bilateral Ovary",
-								"radiation_therapy_fractions": 30,
-								"radiation_therapy_dosage": 66,
-								"radiation_boost": false,
-								"reference_radiation_treatment_id": ""
+							{
+								"submitter_specimen_id": "SPECIMEN_5",
+								"pathological_tumour_staging_system": "AJCC 6th edition",
+								"pathological_t_category": "Tis(DCIS)",
+								"pathological_n_category": "N0a",
+								"pathological_m_category": "M1c",
+								"pathological_stage_group": "Stage II bulky",
+								"specimen_collection_date": "2021-02-13",
+								"specimen_storage": "Unknown",
+								"tumour_histological_type": "8620/9",
+								"specimen_anatomic_location": "C34.9",
+								"reference_pathology_confirmed_diagnosis": "No",
+								"reference_pathology_confirmed_tumour_presence": "Yes",
+								"tumour_grading_system": "Gleason grade group system",
+								"tumour_grade": "Grade Group 5",
+								"percent_tumour_cells_range": "20-50%",
+								"percent_tumour_cells_measurement_method": "Image analysis",
+								"specimen_processing": "Cryopreservation in dry ice (dead tissue)",
+								"specimen_laterality": "Not applicable",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_11",
+										"specimen_tissue_source": "Buffy coat",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Normal - tissue adjacent to primary tumour",
+										"sample_type": "polyA+ RNA"
+									}
+								],
+								"biomarkers": []
 							},
+							{
+								"submitter_specimen_id": "SPECIMEN_6",
+								"pathological_tumour_staging_system": "AJCC 7th edition",
+								"pathological_t_category": "T3e",
+								"pathological_n_category": "N3a",
+								"pathological_m_category": "M1",
+								"pathological_stage_group": "Stage IVAS",
+								"specimen_collection_date": "2020-10-18",
+								"specimen_storage": "RNA later frozen",
+								"tumour_histological_type": "8620/9",
+								"specimen_anatomic_location": "C67.6",
+								"reference_pathology_confirmed_diagnosis": "Yes",
+								"reference_pathology_confirmed_tumour_presence": "No",
+								"tumour_grading_system": "Four-tier grading system",
+								"tumour_grade": "Grade 4",
+								"percent_tumour_cells_range": "51-100%",
+								"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
+								"specimen_processing": "Cryopreservation in dry ice (dead tissue)",
+								"specimen_laterality": "Unknown",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_12",
+										"specimen_tissue_source": "Amniotic fluid",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Primary tumour - additional new primary",
+										"sample_type": "Protein"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_4",
+								"is_primary_treatment": "No",
+								"treatment_start_date": "2021-09",
+								"treatment_end_date": "2022-09",
+								"treatment_setting": "Radiosensitization",
+								"treatment_intent": "Guidance",
+								"days_per_cycle": 4,
+								"number_of_cycles": 5,
+								"line_of_treatment": 5,
+								"status_of_treatment": "Physician decision (stopped or interrupted treatment)",
+								"treatment_type": [
+									"Surgery",
+									"Radiation therapy"
+								],
+								"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
+								"response_to_treatment": "Physician assessed partial response",
+								"chemotherapies": [
+									{
+										"chemotherapy_drug_dose_units": "mg/m2",
+										"drug_reference_database": "PubChem",
+										"drug_name": "NIVOLUMAB",
+										"drug_reference_identifier": "87354",
+										"prescribed_cumulative_drug_dose": 150,
+										"actual_cumulative_drug_dose": 111
+									}
+								],
+								"hormone_therapies": [],
+								"immunotherapies": [],
 
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_19",
-									"date_of_followup": "2022-09",
-									"disease_status_at_followup": "Complete remission",
-									"relapse_type": "Progression (liquid tumours)",
-									"date_of_relapse": "2022-01",
-									"method_of_progression_status": [
-										"Histopathology test (procedure)",
-										"Laboratory data interpretation (procedure)"
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_10",
+										"date_of_followup": "2022-08",
+										"disease_status_at_followup": "Distant progression",
+										"relapse_type": "Local recurrence and distant metastasis",
+										"date_of_relapse": "2022-08",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C01",
+										"recurrence_tumour_staging_system": "Binet staging system",
+										"recurrence_t_category": "T1a(s)",
+										"recurrence_n_category": "N4",
+										"recurrence_m_category": "M0(i+)",
+										"recurrence_stage_group": "Stage IE",
+										"biomarkers": []
+									},
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_9",
+										"date_of_followup": "2022-11",
+										"disease_status_at_followup": "Distant progression",
+										"relapse_type": "Progression (liquid tumours)",
+										"date_of_relapse": "2022-08",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C10",
+										"recurrence_tumour_staging_system": "Revised International staging system (RISS)",
+										"recurrence_t_category": "T2b",
+										"recurrence_n_category": "N2c",
+										"recurrence_m_category": "MX",
+										"recurrence_stage_group": "Stage IBS",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							},
+							{
+								"submitter_treatment_id": "TREATMENT_5",
+								"is_primary_treatment": "No",
+								"treatment_start_date": "2021-05",
+								"treatment_end_date": "2022-05",
+								"treatment_setting": "Conditioning",
+								"treatment_intent": "Curative",
+								"days_per_cycle": 5,
+								"number_of_cycles": 5,
+								"line_of_treatment": 1,
+								"status_of_treatment": "Treatment stopped due to acute toxicity",
+								"treatment_type": [
+									"Surgery",
+									"Radiation therapy"
+								],
+								"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
+								"response_to_treatment": "Stable disease",
+								"chemotherapies": [],
+								"hormone_therapies": [
+									{
+										"hormone_drug_dose_units": "IU/kg",
+										"drug_reference_database": "RxNorm",
+										"drug_name": "leuprolide",
+										"drug_reference_identifier": "258494",
+										"prescribed_cumulative_drug_dose": 160,
+										"actual_cumulative_drug_dose": 73
+									},
+									{
+										"hormone_drug_dose_units": "mg/m2",
+										"drug_reference_database": "PubChem",
+										"drug_name": "degarelix",
+										"drug_reference_identifier": "258494",
+										"prescribed_cumulative_drug_dose": 106,
+										"actual_cumulative_drug_dose": 114
+									},
+									{
+										"hormone_drug_dose_units": "ug/m2",
+										"drug_reference_database": "PubChem",
+										"drug_name": "degarelix",
+										"drug_reference_identifier": "46475",
+										"prescribed_cumulative_drug_dose": 179,
+										"actual_cumulative_drug_dose": 97
+									}
+								],
+								"immunotherapies": [],
+
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_11",
+										"date_of_followup": "2022-10",
+										"disease_status_at_followup": "Relapse or recurrence",
+										"relapse_type": "Local recurrence and distant metastasis",
+										"date_of_relapse": "2022-02",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C13",
+										"recurrence_tumour_staging_system": "Revised International staging system (RISS)",
+										"recurrence_t_category": "T4a(s)",
+										"recurrence_n_category": "N4",
+										"recurrence_m_category": "M1b",
+										"recurrence_stage_group": "Stage IVA",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							},
+							{
+								"submitter_treatment_id": "TREATMENT_6",
+								"is_primary_treatment": "Unknown",
+								"treatment_start_date": "2021-04",
+								"treatment_end_date": "2022-10",
+								"treatment_setting": "Neoadjuvant",
+								"treatment_intent": "Guidance",
+								"days_per_cycle": 3,
+								"number_of_cycles": 3,
+								"line_of_treatment": 1,
+								"status_of_treatment": "Unknown",
+								"treatment_type": [
+									"Radiation therapy",
+									"Surgery"
+								],
+								"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
+								"response_to_treatment": "Immune partial response (iPR)",
+								"chemotherapies": [],
+								"hormone_therapies": [
+									{
+										"hormone_drug_dose_units": "IU/m2",
+										"drug_reference_database": "PubChem",
+										"drug_name": "leuprolide",
+										"drug_reference_identifier": "258494",
+										"prescribed_cumulative_drug_dose": 71,
+										"actual_cumulative_drug_dose": 92
+									},
+									{
+										"hormone_drug_dose_units": "g/m2",
+										"drug_reference_database": "NCI Thesaurus",
+										"drug_name": "triptorelin",
+										"drug_reference_identifier": "258494",
+										"prescribed_cumulative_drug_dose": 76,
+										"actual_cumulative_drug_dose": 156
+									}
+								],
+								"immunotherapies": [],
+
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_12",
+										"date_of_followup": "2022-08",
+										"disease_status_at_followup": "Stable",
+										"relapse_type": "Local recurrence",
+										"date_of_relapse": "2022-05",
+										"method_of_progression_status": [
+											"Physical examination procedure (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C06",
+										"recurrence_tumour_staging_system": "Rai staging system",
+										"recurrence_t_category": "T3e",
+										"recurrence_n_category": "N1b",
+										"recurrence_m_category": "M1c",
+										"recurrence_stage_group": "Stage A",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					},
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_3",
+						"date_of_diagnosis": "2019-09",
+						"cancer_type_code": "C64.9",
+						"basis_of_diagnosis": "Clinical investigation",
+						"lymph_nodes_examined_status": "No lymph nodes found in resected specimen",
+						"lymph_nodes_examined_method": "Lymph node dissection/pathological exam",
+						"number_lymph_nodes_positive": 9,
+						"clinical_tumour_staging_system": "FIGO staging system",
+						"clinical_t_category": "T1d",
+						"clinical_n_category": "N1a(sn)",
+						"clinical_m_category": "M0(i+)",
+						"clinical_stage_group": "Stage IIE",
+						"laterality": "Left",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_7",
+								"pathological_tumour_staging_system": "AJCC 6th edition",
+								"pathological_t_category": "Tis(LCIS)",
+								"pathological_n_category": "N2b",
+								"pathological_m_category": "M1a(0)",
+								"pathological_stage_group": "Stage L1",
+								"specimen_collection_date": "2020-10-19",
+								"specimen_storage": "Frozen in -70 freezer",
+								"tumour_histological_type": "8830/6",
+								"specimen_anatomic_location": "C50.9",
+								"reference_pathology_confirmed_diagnosis": "Unknown",
+								"reference_pathology_confirmed_tumour_presence": "Not done",
+								"tumour_grading_system": "Four-tier grading system",
+								"tumour_grade": "G4",
+								"percent_tumour_cells_range": "0-19%",
+								"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
+								"specimen_processing": "Cryopreservation of live cells in liquid nitrogen",
+								"specimen_laterality": "Unknown",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_13",
+										"specimen_tissue_source": "Saliva",
+										"tumour_normal_designation": "Normal",
+										"specimen_type": "Recurrent tumour",
+										"sample_type": "ctDNA"
+									}
+								],
+								"biomarkers": []
+							},
+							{
+								"submitter_specimen_id": "SPECIMEN_8",
+								"pathological_tumour_staging_system": "Lugano staging system",
+								"pathological_t_category": "T4e",
+								"pathological_n_category": "N1b",
+								"pathological_m_category": "M1d",
+								"pathological_stage_group": "Stage IS",
+								"specimen_collection_date": "2020-02-29",
+								"specimen_storage": "Cut slide",
+								"tumour_histological_type": "8962/1",
+								"specimen_anatomic_location": "C43.1",
+								"reference_pathology_confirmed_diagnosis": "Not done",
+								"reference_pathology_confirmed_tumour_presence": "Not done",
+								"tumour_grading_system": "Grading system for GISTs",
+								"tumour_grade": "GX",
+								"percent_tumour_cells_range": "0-19%",
+								"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
+								"specimen_processing": "Cryopreservation in dry ice (dead tissue)",
+								"specimen_laterality": "Left",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_14",
+										"specimen_tissue_source": "Urine",
+										"tumour_normal_designation": "Normal",
+										"specimen_type": "Xenograft - derived from metastatic tumour",
+										"sample_type": "Total RNA"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_7",
+								"is_primary_treatment": "No",
+								"treatment_start_date": "2021-04",
+								"treatment_end_date": "2022-03",
+								"treatment_setting": "Mobilization",
+								"treatment_intent": "Curative",
+								"days_per_cycle": 3,
+								"number_of_cycles": 5,
+								"line_of_treatment": 3,
+								"status_of_treatment": "Other",
+								"treatment_type": [
+									"Chemotherapy",
+									"Hormonal therapy"
+								],
+								"response_to_treatment_criteria_method": "iRECIST",
+								"response_to_treatment": "Immune complete response (iCR)",
+								"chemotherapies": [],
+								"hormone_therapies": [
+									{
+										"hormone_drug_dose_units": "g/m2",
+										"drug_reference_database": "PubChem",
+										"drug_name": "goserelin",
+										"drug_reference_identifier": "557845",
+										"prescribed_cumulative_drug_dose": 187,
+										"actual_cumulative_drug_dose": 133
+									}
+								],
+								"immunotherapies": [],
+
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_13",
+										"date_of_followup": "2022-10",
+										"disease_status_at_followup": "Stable",
+										"relapse_type": "Progression (liquid tumours)",
+										"date_of_relapse": "2021-12",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C09",
+										"recurrence_tumour_staging_system": "AJCC 7th edition",
+										"recurrence_t_category": "T1b(s)",
+										"recurrence_n_category": "N1a(sn)",
+										"recurrence_m_category": "M1b(1)",
+										"recurrence_stage_group": "Stage IAB",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							},
+							{
+								"submitter_treatment_id": "TREATMENT_8",
+								"is_primary_treatment": "Unknown",
+								"treatment_start_date": "2021-08",
+								"treatment_end_date": "2022-01",
+								"treatment_setting": "Induction",
+								"treatment_intent": "Palliative",
+								"days_per_cycle": 3,
+								"number_of_cycles": 5,
+								"line_of_treatment": 1,
+								"status_of_treatment": "Unknown",
+								"treatment_type": [
+									"Hormonal therapy"
+								],
+								"response_to_treatment_criteria_method": "RECIST 1.1",
+								"response_to_treatment": "Immune confirmed progressive disease (iCPD)",
+								"chemotherapies": [],
+								"hormone_therapies": [
+									{
+										"hormone_drug_dose_units": "IU/m2",
+										"drug_reference_database": "RxNorm",
+										"drug_name": "exemestane",
+										"drug_reference_identifier": "223986",
+										"prescribed_cumulative_drug_dose": 124,
+										"actual_cumulative_drug_dose": 134
+									}
+								],
+								"immunotherapies": [],
+
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_14",
+										"date_of_followup": "2022-11",
+										"disease_status_at_followup": "Relapse or recurrence",
+										"relapse_type": "Biochemical progression",
+										"date_of_relapse": "2022-02",
+										"method_of_progression_status": [
+											"Assessment of symptom control (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C03",
+										"recurrence_tumour_staging_system": "AJCC 6th edition",
+										"recurrence_t_category": "T3d",
+										"recurrence_n_category": "N2a",
+										"recurrence_m_category": "M1b",
+										"recurrence_stage_group": "Stage IS",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					}
+				],
+				"comorbidities": [
+					{
+						"prior_malignancy": "Yes",
+						"laterality_of_prior_malignancy": "Right",
+						"comorbidity_type_code": "C34.9",
+						"comorbidity_treatment_status": "Unknown",
+						"comorbidity_treatment": "Ablation",
+						"age_at_comorbidity_diagnosis": 44
+					},
+					{
+						"prior_malignancy": "Yes",
+						"laterality_of_prior_malignancy": "Unilateral, Side not specified",
+						"comorbidity_type_code": "C43.9",
+						"comorbidity_treatment_status": "Yes",
+						"comorbidity_treatment": "Hormonal therapy",
+						"age_at_comorbidity_diagnosis": 46
+					},
+					{
+						"prior_malignancy": "No",
+						"laterality_of_prior_malignancy": "Unilateral, Side not specified",
+						"comorbidity_type_code": "C02.1",
+						"comorbidity_treatment_status": "Yes",
+						"comorbidity_treatment": "Endoscopic therapy",
+						"age_at_comorbidity_diagnosis": 40
+					}
+				],
+				"exposures": [
+					{
+						"tobacco_smoking_status": "Current smoker",
+						"tobacco_type": [
+							"Unknown",
+							"Electronic cigarettes",
+							"Not applicable"
+						],
+						"pack_years_smoked": 280.0
+					},
+					{
+						"tobacco_smoking_status": "Not applicable",
+						"tobacco_type": [
+							"Chewing Tobacco",
+							"Pipe",
+							"Not applicable"
+						],
+						"pack_years_smoked": 138.0
+					},
+					{
+						"tobacco_smoking_status": "Not applicable",
+						"tobacco_type": [
+							"Cigar",
+							"Waterpipe",
+							"Electronic cigarettes"
+						],
+						"pack_years_smoked": 141.0
+					}
+				],
+				"biomarkers": [],
+				"followups": []
+			},
+			{
+				"submitter_donor_id": "DONOR_10",
+				"program_id": "SYNTHETIC-2",
+				"lost_to_followup_after_clinical_event_identifier": "",
+				"lost_to_followup_reason": "Not applicable",
+				"date_alive_after_lost_to_followup": "2022-03",
+				"is_deceased": true,
+				"cause_of_death": "Unknown",
+				"date_of_birth": "1987-09",
+				"date_of_death": "2015-09",
+				"gender": "Woman",
+				"sex_at_birth": "Other",
+				"primary_site": [
+					"Esophagus",
+					"Base of tongue",
+					"Nasal cavity and middle ear"
+				],
+				"primary_diagnoses": [
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_16",
+						"date_of_diagnosis": "2019-10",
+						"cancer_type_code": "C43.9",
+						"basis_of_diagnosis": "Histology of a primary tumour",
+						"lymph_nodes_examined_status": "No lymph nodes found in resected specimen",
+						"lymph_nodes_examined_method": "Physical palpation of patient",
+						"number_lymph_nodes_positive": 10,
+						"clinical_tumour_staging_system": "Binet staging system",
+						"clinical_t_category": "T4b",
+						"clinical_n_category": "N0(mol-)",
+						"clinical_m_category": "M1a(1)",
+						"clinical_stage_group": "Stage IBS",
+						"laterality": "Bilateral",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_22",
+								"pathological_tumour_staging_system": "Durie-Salmon staging system",
+								"pathological_t_category": "T3e",
+								"pathological_n_category": "N0(mol+)",
+								"pathological_m_category": "M0",
+								"pathological_stage_group": "Stage IIBES",
+								"specimen_collection_date": "2021-04-20",
+								"specimen_storage": "Paraffin block",
+								"tumour_histological_type": "8124/9",
+								"specimen_anatomic_location": "C43.9",
+								"reference_pathology_confirmed_diagnosis": "Unknown",
+								"reference_pathology_confirmed_tumour_presence": "Not done",
+								"tumour_grading_system": "Scarff-Bloom-Richardson grading system",
+								"tumour_grade": "Grade Group 3",
+								"percent_tumour_cells_range": "20-50%",
+								"percent_tumour_cells_measurement_method": "Image analysis",
+								"specimen_processing": "Other",
+								"specimen_laterality": "Right",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_28",
+										"specimen_tissue_source": "Venous blood",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Primary tumour - adjacent to normal",
+										"sample_type": "Total RNA"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_22",
+								"is_primary_treatment": "Yes",
+								"treatment_start_date": "2021-10",
+								"treatment_end_date": "2022-07",
+								"treatment_setting": "Neoadjuvant",
+								"treatment_intent": "Diagnostic",
+								"days_per_cycle": 6,
+								"number_of_cycles": 4,
+								"line_of_treatment": 1,
+								"status_of_treatment": "Treatment incomplete due to technical or organizational problems",
+								"treatment_type": [
+									"Surgery"
+								],
+								"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
+								"response_to_treatment": "Partial response",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [],
+								"surgery": {
+									"surgery_type": "Pneumonectomy",
+									"surgery_site": "C14",
+									"surgery_location": "Primary",
+									"tumour_focality": "Unifocal",
+									"residual_tumour_classification": "R2",
+									"margin_types_involved": [
+										"Unknown"
 									],
-									"anatomic_site_progression_or_recurrence": "C14",
-									"recurrence_tumour_staging_system": "International Neuroblastoma Staging System",
-									"recurrence_t_category": "T2a2",
-									"recurrence_n_category": "N3",
-									"recurrence_m_category": "M0",
-									"recurrence_stage_group": "Stage IAS",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				},
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_8",
-					"date_of_diagnosis": "2019-05",
-					"cancer_type_code": "C43.1",
-					"basis_of_diagnosis": "Clinical investigation",
-					"lymph_nodes_examined_status": "No",
-					"lymph_nodes_examined_method": "Lymph node dissection/pathological exam",
-					"number_lymph_nodes_positive": 7,
-					"clinical_tumour_staging_system": "FIGO staging system",
-					"clinical_t_category": "T3a",
-					"clinical_n_category": "N4",
-					"clinical_m_category": "M0",
-					"clinical_stage_group": "Stage IIS",
-					"laterality": "Bilateral",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_14",
-							"pathological_tumour_staging_system": "SEER staging system",
-							"pathological_t_category": "T4c",
-							"pathological_n_category": "N1a(sn)",
-							"pathological_m_category": "M1b(0)",
-							"pathological_stage_group": "Stage IAB",
-							"specimen_collection_date": "2021-11-26",
-							"specimen_storage": "Other",
-							"tumour_histological_type": "8289/9",
-							"specimen_anatomic_location": "C43.9",
-							"reference_pathology_confirmed_diagnosis": "Not done",
-							"reference_pathology_confirmed_tumour_presence": "No",
-							"tumour_grading_system": "FNCLCC grading system",
-							"tumour_grade": "High grade",
-							"percent_tumour_cells_range": "51-100%",
-							"percent_tumour_cells_measurement_method": "Unknown",
-							"specimen_processing": "Unknown",
-							"specimen_laterality": "Unknown",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_20",
-									"specimen_tissue_source": "Sputum",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Normal",
-									"sample_type": "Protein"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_14",
-							"is_primary_treatment": "No",
-							"treatment_start_date": "2021-09",
-							"treatment_end_date": "2022-11",
-							"treatment_setting": "Preventative",
-							"treatment_intent": "Palliative",
-							"days_per_cycle": 2,
-							"number_of_cycles": 4,
-							"line_of_treatment": 3,
-							"status_of_treatment": "Treatment stopped due to lack of efficacy (disease progression)",
-							"treatment_type": [
-								"Chemotherapy",
-								"Immunotherapy",
-								"Stem cell transplant"
-							],
-							"response_to_treatment_criteria_method": "RECIST 1.1",
-							"response_to_treatment": "Immune complete response (iCR)",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [
-								{
-									"immunotherapy_type": "Cell-based",
-									"drug_reference_database": "RxNorm",
-									"immunotherapy_drug_dose_units": "IU/kg",
-									"drug_name": "Pembrolizumab",
-									"drug_reference_identifier": "4459876",
-									"prescribed_cumulative_drug_dose": 95,
-									"actual_cumulative_drug_dose": 160
+									"margin_types_not_involved": [
+										"Circumferential resection margin"
+									],
+									"margin_types_not_assessed": [
+										"Distal margin",
+										"Proximal margin"
+									],
+									"lymphovascular_invasion": "Unknown",
+									"perineural_invasion": "Unknown",
+									"tumour_length": 3,
+									"tumour_width": 5,
+									"greatest_dimension_tumour": 5,
+									"submitter_specimen_id": null
 								},
-								{
-									"immunotherapy_type": "Other immunomodulatory substances",
-									"drug_reference_database": "PubChem",
-									"immunotherapy_drug_dose_units": "ug/m2",
-									"drug_name": "Pexidartinib",
-									"drug_reference_identifier": "8836851",
-									"prescribed_cumulative_drug_dose": 197,
-									"actual_cumulative_drug_dose": 183
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_28",
+										"date_of_followup": "2022-08",
+										"disease_status_at_followup": "Loco-regional progression",
+										"relapse_type": "Local recurrence",
+										"date_of_relapse": "2022-06",
+										"method_of_progression_status": [
+											"Histopathology test (procedure)",
+											"Physical examination procedure (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C10",
+										"recurrence_tumour_staging_system": "AJCC 6th edition",
+										"recurrence_t_category": "T3",
+										"recurrence_n_category": "N0(i+)",
+										"recurrence_m_category": "M1c(0)",
+										"recurrence_stage_group": "Stage 4",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					}
+				],
+				"comorbidities": [],
+				"exposures": [],
+				"biomarkers": [],
+				"followups": []
+			},
+			{
+				"submitter_donor_id": "DONOR_2",
+				"program_id": "SYNTHETIC-2",
+				"lost_to_followup_after_clinical_event_identifier": "",
+				"lost_to_followup_reason": "Discharged to palliative care",
+				"date_alive_after_lost_to_followup": "2022-10",
+				"is_deceased": false,
+				"cause_of_death": "Died of other reasons",
+				"date_of_birth": "1994-06",
+				"date_of_death": null,
+				"gender": "Man",
+				"sex_at_birth": "Male",
+				"primary_site": [
+					"Bronchus and lung",
+					"Larynx",
+					"Pancreas"
+				],
+				"primary_diagnoses": [
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_4",
+						"date_of_diagnosis": "2019-09",
+						"cancer_type_code": "C04.9",
+						"basis_of_diagnosis": "Clinical investigation",
+						"lymph_nodes_examined_status": "Not applicable",
+						"lymph_nodes_examined_method": "Physical palpation of patient",
+						"number_lymph_nodes_positive": 8,
+						"clinical_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
+						"clinical_t_category": "T4a",
+						"clinical_n_category": "N0",
+						"clinical_m_category": "M1b(1)",
+						"clinical_stage_group": "Stage IIA1",
+						"laterality": "Unknown",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_10",
+								"pathological_tumour_staging_system": "Rai staging system",
+								"pathological_t_category": "TX",
+								"pathological_n_category": "N0",
+								"pathological_m_category": "M1d(1)",
+								"pathological_stage_group": "Stage 1",
+								"specimen_collection_date": "2020-12-26",
+								"specimen_storage": "Cut slide",
+								"tumour_histological_type": "8630/9",
+								"specimen_anatomic_location": "C34.9",
+								"reference_pathology_confirmed_diagnosis": "Unknown",
+								"reference_pathology_confirmed_tumour_presence": "Yes",
+								"tumour_grading_system": "Nuclear grading system for DCIS",
+								"tumour_grade": "High grade",
+								"percent_tumour_cells_range": "51-100%",
+								"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
+								"specimen_processing": "Cryopreservation of live cells in liquid nitrogen",
+								"specimen_laterality": "Right",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_16",
+										"specimen_tissue_source": "Bile",
+										"tumour_normal_designation": "Normal",
+										"specimen_type": "Metastatic tumour - additional metastatic",
+										"sample_type": "polyA+ RNA"
+									}
+								],
+								"biomarkers": []
+							},
+							{
+								"submitter_specimen_id": "SPECIMEN_9",
+								"pathological_tumour_staging_system": "AJCC 6th edition",
+								"pathological_t_category": "T4b",
+								"pathological_n_category": "N0a (biopsy)",
+								"pathological_m_category": "M1a(0)",
+								"pathological_stage_group": "Stage IIID",
+								"specimen_collection_date": "2021-07-29",
+								"specimen_storage": "RNA later frozen",
+								"tumour_histological_type": "8973/2",
+								"specimen_anatomic_location": "C43.9",
+								"reference_pathology_confirmed_diagnosis": "Unknown",
+								"reference_pathology_confirmed_tumour_presence": "Unknown",
+								"tumour_grading_system": "FNCLCC grading system",
+								"tumour_grade": "Grade 2",
+								"percent_tumour_cells_range": "20-50%",
+								"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
+								"specimen_processing": "Formalin fixed - unbuffered",
+								"specimen_laterality": "Not applicable",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_15",
+										"specimen_tissue_source": "Blood derived - peripheral blood",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Recurrent tumour",
+										"sample_type": "Total RNA"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_10",
+								"is_primary_treatment": "Unknown",
+								"treatment_start_date": "2021-08",
+								"treatment_end_date": "2022-10",
+								"treatment_setting": "Salvage",
+								"treatment_intent": "Forensic",
+								"days_per_cycle": 1,
+								"number_of_cycles": 5,
+								"line_of_treatment": 5,
+								"status_of_treatment": "Not applicable",
+								"treatment_type": [
+									"Radiation therapy",
+									"Bone marrow transplant",
+									"No treatment"
+								],
+								"response_to_treatment_criteria_method": "Physician Assessed Response Criteria",
+								"response_to_treatment": "No evidence of disease (NED)",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [],
+								"radiation": {
+									"radiation_therapy_modality": "Teleradiotherapy protons (procedure)",
+									"radiation_therapy_type": "Internal",
+									"anatomical_site_irradiated": "Finger (Including Thumbs)",
+									"radiation_therapy_fractions": 30,
+									"radiation_therapy_dosage": 66,
+									"radiation_boost": true,
+									"reference_radiation_treatment_id": "REFERENCE_RADIATION_TREATMENT_2"
 								},
-								{
-									"immunotherapy_type": "Monoclonal antibodies other than immune checkpoint inhibitors",
-									"drug_reference_database": "RxNorm",
-									"immunotherapy_drug_dose_units": "cells/kg",
-									"drug_name": "Copanlisib",
-									"drug_reference_identifier": "278936",
-									"prescribed_cumulative_drug_dose": 183,
-									"actual_cumulative_drug_dose": 100
-								}
-							],
 
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_20",
-									"date_of_followup": "2022-11",
-									"disease_status_at_followup": "Distant progression",
-									"relapse_type": "Local recurrence and distant metastasis",
-									"date_of_relapse": "2022-09",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C20",
-									"recurrence_tumour_staging_system": "AJCC 8th edition",
-									"recurrence_t_category": "T3a",
-									"recurrence_n_category": "N0(i-)",
-									"recurrence_m_category": "M1b(0)",
-									"recurrence_stage_group": "Stage IVBE",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				}
-			],
-			"comorbidities": [
-				{
-					"prior_malignancy": "Yes",
-					"laterality_of_prior_malignancy": "Bilateral",
-					"comorbidity_type_code": "C67.6",
-					"comorbidity_treatment_status": "Unknown",
-					"comorbidity_treatment": "Ablation",
-					"age_at_comorbidity_diagnosis": 41
-				},
-				{
-					"prior_malignancy": "No",
-					"laterality_of_prior_malignancy": "Left",
-					"comorbidity_type_code": "C43.9",
-					"comorbidity_treatment_status": "Unknown",
-					"comorbidity_treatment": "Endoscopic therapy",
-					"age_at_comorbidity_diagnosis": 46
-				}
-			],
-			"exposures": [
-				{
-					"tobacco_smoking_status": "Current reformed smoker for > 15 years",
-					"tobacco_type": [
-						"Waterpipe",
-						"Unknown"
-					],
-					"pack_years_smoked": 29.0
-				}
-			],
-			"biomarkers": [
-				{
-					"er_status": "Cannot be determined",
-					"pr_status": "Unknown",
-					"her2_ihc_status": "Not applicable",
-					"her2_ish_status": "Cannot be determined",
-					"hpv_ihc_status": "Negative",
-					"hpv_pcr_status": "Cannot be determined",
-					"hpv_strain": [
-						"HPV39",
-						"HPV16"
-					],
-					"test_interval": 4,
-					"psa_level": 245,
-					"ca125": 46,
-					"cea": 11,
-					"er_percent_positive": 59.9,
-					"pr_percent_positive": 39.7
-				}
-			],
-			"followups": []
-		},
-		{
-			"submitter_donor_id": "DONOR_4",
-			"program_id": "SYNTHETIC-2",
-			"lost_to_followup_after_clinical_event_identifier": "",
-			"lost_to_followup_reason": "Withdrew from study",
-			"date_alive_after_lost_to_followup": "2022-04",
-			"is_deceased": false,
-			"cause_of_death": "Died of cancer",
-			"date_of_birth": "1984-10",
-			"date_of_death": null,
-			"gender": "Man",
-			"sex_at_birth": "Male",
-			"primary_site": [
-				"Skin",
-				"Bronchus and lung",
-				"Prostate gland"
-			],
-			"primary_diagnoses": [
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_10",
-					"date_of_diagnosis": "2019-05",
-					"cancer_type_code": "C43.9",
-					"basis_of_diagnosis": "Cytology",
-					"lymph_nodes_examined_status": "Cannot be determined",
-					"lymph_nodes_examined_method": "Lymph node dissection/pathological exam",
-					"number_lymph_nodes_positive": 4,
-					"clinical_tumour_staging_system": "International Neuroblastoma Staging System",
-					"clinical_t_category": "Tis(Paget)",
-					"clinical_n_category": "N2a",
-					"clinical_m_category": "M1e",
-					"clinical_stage_group": "Stage Ms",
-					"laterality": "Left",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_16",
-							"pathological_tumour_staging_system": "Revised International staging system (RISS)",
-							"pathological_t_category": "T2(m)",
-							"pathological_n_category": "N1a(sn)",
-							"pathological_m_category": "M1c",
-							"pathological_stage_group": "Stage IIBE",
-							"specimen_collection_date": "2020-07-14",
-							"specimen_storage": "Frozen in vapour phase",
-							"tumour_histological_type": "8240/1",
-							"specimen_anatomic_location": "C67.6",
-							"reference_pathology_confirmed_diagnosis": "Not done",
-							"reference_pathology_confirmed_tumour_presence": "Not done",
-							"tumour_grading_system": "Scarff-Bloom-Richardson grading system",
-							"tumour_grade": "Grade 2",
-							"percent_tumour_cells_range": "20-50%",
-							"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
-							"specimen_processing": "Cryopreservation in dry ice (dead tissue)",
-							"specimen_laterality": "Unknown",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_22",
-									"specimen_tissue_source": "Cervical mucus",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Primary tumour - additional new primary",
-									"sample_type": "ctDNA"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_16",
-							"is_primary_treatment": "Yes",
-							"treatment_start_date": "2021-01",
-							"treatment_end_date": "2022-04",
-							"treatment_setting": "Conditioning",
-							"treatment_intent": "Diagnostic",
-							"days_per_cycle": 2,
-							"number_of_cycles": 4,
-							"line_of_treatment": 5,
-							"status_of_treatment": "Patient choice (stopped or interrupted treatment)",
-							"treatment_type": [
-								"Bone marrow transplant",
-								"Surgery",
-								"Radiation therapy"
-							],
-							"response_to_treatment_criteria_method": "iRECIST",
-							"response_to_treatment": "Physician assessed partial response",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [
-								{
-									"immunotherapy_type": "Monoclonal antibodies other than immune checkpoint inhibitors",
-									"drug_reference_database": "RxNorm",
-									"immunotherapy_drug_dose_units": "IU/kg",
-									"drug_name": "Copanlisib",
-									"drug_reference_identifier": "239766",
-									"prescribed_cumulative_drug_dose": 181,
-									"actual_cumulative_drug_dose": 111
-								}
-							],
-
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_22",
-									"date_of_followup": "2022-10",
-									"disease_status_at_followup": "Stable",
-									"relapse_type": "Distant recurrence/metastasis",
-									"date_of_relapse": "2021-11",
-									"method_of_progression_status": [
-										"Tumor marker measurement (procedure)",
-										"Physical examination procedure (procedure)"
-									],
-									"anatomic_site_progression_or_recurrence": "C18",
-									"recurrence_tumour_staging_system": "Binet staging system",
-									"recurrence_t_category": "T1a(s)",
-									"recurrence_n_category": "N0a (biopsy)",
-									"recurrence_m_category": "M1e",
-									"recurrence_stage_group": "Stage IIBES",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				},
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_9",
-					"date_of_diagnosis": "2019-06",
-					"cancer_type_code": "C04.9",
-					"basis_of_diagnosis": "Clinical",
-					"lymph_nodes_examined_status": "No lymph nodes found in resected specimen",
-					"lymph_nodes_examined_method": "Imaging",
-					"number_lymph_nodes_positive": 15,
-					"clinical_tumour_staging_system": "AJCC 7th edition",
-					"clinical_t_category": "T1a2",
-					"clinical_n_category": "N2c",
-					"clinical_m_category": "M1a(0)",
-					"clinical_stage_group": "Stage IIIBES",
-					"laterality": "Unilateral, side not specified",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_15",
-							"pathological_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
-							"pathological_t_category": "T1b(s)",
-							"pathological_n_category": "N4",
-							"pathological_m_category": "M1c",
-							"pathological_stage_group": "Stage IVB",
-							"specimen_collection_date": "2020-05-31",
-							"specimen_storage": "RNA later frozen",
-							"tumour_histological_type": "8250/3",
-							"specimen_anatomic_location": "C43.9",
-							"reference_pathology_confirmed_diagnosis": "Yes",
-							"reference_pathology_confirmed_tumour_presence": "Not done",
-							"tumour_grading_system": "Grading system for GNETs",
-							"tumour_grade": "High",
-							"percent_tumour_cells_range": "0-19%",
-							"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
-							"specimen_processing": "Cryopreservation of live cells in liquid nitrogen",
-							"specimen_laterality": "Not applicable",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_21",
-									"specimen_tissue_source": "Buccal cell",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Recurrent tumour",
-									"sample_type": "Protein"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_15",
-							"is_primary_treatment": "Yes",
-							"treatment_start_date": "2021-12",
-							"treatment_end_date": "2022-07",
-							"treatment_setting": "Locally advanced",
-							"treatment_intent": "Guidance",
-							"days_per_cycle": 5,
-							"number_of_cycles": 3,
-							"line_of_treatment": 2,
-							"status_of_treatment": "Treatment stopped due to lack of efficacy (disease progression)",
-							"treatment_type": [
-								"Stem cell transplant",
-								"Immunotherapy",
-								"Hormonal therapy"
-							],
-							"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
-							"response_to_treatment": "Complete remission with incomplete hematologic recovery (CRi)",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [
-								{
-									"immunotherapy_type": "Cell-based",
-									"drug_reference_database": "NCI Thesaurus",
-									"immunotherapy_drug_dose_units": "IU/kg",
-									"drug_name": "Necitumumab",
-									"drug_reference_identifier": "278936",
-									"prescribed_cumulative_drug_dose": 138,
-									"actual_cumulative_drug_dose": 167
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_16",
+										"date_of_followup": "2022-09",
+										"disease_status_at_followup": "Loco-regional progression",
+										"relapse_type": "Distant recurrence/metastasis",
+										"date_of_relapse": "2022-10",
+										"method_of_progression_status": [
+											"Laboratory data interpretation (procedure)",
+											"Histopathology test (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C14",
+										"recurrence_tumour_staging_system": "St Jude staging system",
+										"recurrence_t_category": "T2(m)",
+										"recurrence_n_category": "N0b",
+										"recurrence_m_category": "M1c(1)",
+										"recurrence_stage_group": "Stage IB",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							},
+							{
+								"submitter_treatment_id": "TREATMENT_9",
+								"is_primary_treatment": "Unknown",
+								"treatment_start_date": "2021-07",
+								"treatment_end_date": "2022-11",
+								"treatment_setting": "Maintenance",
+								"treatment_intent": "Supportive",
+								"days_per_cycle": 7,
+								"number_of_cycles": 5,
+								"line_of_treatment": 4,
+								"status_of_treatment": "Treatment incomplete due to technical or organizational problems",
+								"treatment_type": [
+									"Surgery"
+								],
+								"response_to_treatment_criteria_method": "RECIST 1.1",
+								"response_to_treatment": "Immune confirmed progressive disease (iCPD)",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [],
+								"radiation": {
+									"radiation_therapy_modality": "Teleradiotherapy neutrons (procedure)",
+									"radiation_therapy_type": "Internal",
+									"anatomical_site_irradiated": "Left Maxilla",
+									"radiation_therapy_fractions": 30,
+									"radiation_therapy_dosage": 66,
+									"radiation_boost": true,
+									"reference_radiation_treatment_id": "REFERENCE_RADIATION_TREATMENT_1"
 								},
-								{
-									"immunotherapy_type": "Immune checkpoint inhibitors",
-									"drug_reference_database": "PubChem",
-									"immunotherapy_drug_dose_units": "g/m2",
-									"drug_name": "Pexidartinib",
-									"drug_reference_identifier": "278936",
-									"prescribed_cumulative_drug_dose": 184,
-									"actual_cumulative_drug_dose": 190
-								}
-							],
 
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_21",
-									"disease_status_at_followup": "Loco-regional progression",
-									"relapse_type": "Progression (liquid tumours)",
-									"date_of_relapse": "2021-12",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C18",
-									"recurrence_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
-									"recurrence_t_category": "T4",
-									"recurrence_n_category": "N0a (biopsy)",
-									"recurrence_m_category": "M1",
-									"recurrence_stage_group": "Stage IB2",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				}
-			],
-			"comorbidities": [
-				{
-					"prior_malignancy": "No",
-					"laterality_of_prior_malignancy": "Unknown",
-					"comorbidity_type_code": "C67.6",
-					"comorbidity_treatment_status": "Unknown",
-					"comorbidity_treatment": "Radiation therapy",
-					"age_at_comorbidity_diagnosis": 47
-				},
-				{
-					"prior_malignancy": "No",
-					"laterality_of_prior_malignancy": "Unknown",
-					"comorbidity_type_code": "C02.0",
-					"comorbidity_treatment_status": "No",
-					"comorbidity_treatment": "Photodynamic therapy",
-					"age_at_comorbidity_diagnosis": 35
-				}
-			],
-			"exposures": [],
-			"biomarkers": [],
-			"followups": []
-		},
-		{
-			"submitter_donor_id": "DONOR_5",
-			"program_id": "SYNTHETIC-2",
-			"lost_to_followup_after_clinical_event_identifier": "",
-			"lost_to_followup_reason": "Completed study",
-			"date_alive_after_lost_to_followup": "2022-02",
-			"is_deceased": true,
-			"cause_of_death": "Died of other reasons",
-			"date_of_birth": "1998-08",
-			"date_of_death": "2013-08",
-			"gender": "Non-binary",
-			"sex_at_birth": "Other",
-			"primary_site": [
-				"Connective, subcutaneous and other soft tissues",
-				"Penis",
-				"Thyroid gland",
-				"Adrenal gland"
-			],
-			"primary_diagnoses": [
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_11",
-					"date_of_diagnosis": "2019-07",
-					"cancer_type_code": "C64.9",
-					"basis_of_diagnosis": "Specific tumour markers",
-					"lymph_nodes_examined_status": "Cannot be determined",
-					"lymph_nodes_examined_method": "Physical palpation of patient",
-					"number_lymph_nodes_positive": 15,
-					"clinical_tumour_staging_system": "Rai staging system",
-					"clinical_t_category": "T4b",
-					"clinical_n_category": "N0(i+)",
-					"clinical_m_category": "M1e",
-					"clinical_stage_group": "Stage IIBES",
-					"laterality": "Bilateral",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_17",
-							"pathological_tumour_staging_system": "AJCC 8th edition",
-							"pathological_t_category": "T4a(m)",
-							"pathological_n_category": "N0b",
-							"pathological_m_category": "M1c(0)",
-							"pathological_stage_group": "Stage IIIA2",
-							"specimen_collection_date": "2021-03-02",
-							"specimen_storage": "Frozen in -70 freezer",
-							"tumour_histological_type": "8970/3",
-							"specimen_anatomic_location": "C43.9",
-							"reference_pathology_confirmed_diagnosis": "Unknown",
-							"reference_pathology_confirmed_tumour_presence": "Yes",
-							"tumour_grading_system": "Grading system for GISTs",
-							"tumour_grade": "Grade 4",
-							"percent_tumour_cells_range": "0-19%",
-							"percent_tumour_cells_measurement_method": "Image analysis",
-							"specimen_processing": "Unknown",
-							"specimen_laterality": "Not applicable",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_23",
-									"specimen_tissue_source": "Pleural fluid",
-									"tumour_normal_designation": "Tumour",
-									"specimen_type": "Xenograft - derived from metastatic tumour",
-									"sample_type": "Other RNA fractions"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_17",
-							"is_primary_treatment": "Yes",
-							"treatment_start_date": "2021-02",
-							"treatment_end_date": "2022-06",
-							"treatment_setting": "Conditioning",
-							"treatment_intent": "Forensic",
-							"days_per_cycle": 6,
-							"number_of_cycles": 3,
-							"line_of_treatment": 1,
-							"status_of_treatment": "Treatment incomplete due to technical or organizational problems",
-							"treatment_type": [
-								"Immunotherapy",
-								"Surgery",
-								"No treatment"
-							],
-							"response_to_treatment_criteria_method": "RECIST 1.1",
-							"response_to_treatment": "Partial remission",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [
-								{
-									"immunotherapy_type": "Monoclonal antibodies other than immune checkpoint inhibitors",
-									"drug_reference_database": "NCI Thesaurus",
-									"immunotherapy_drug_dose_units": "IU/m2",
-									"drug_name": "Gilteritinib",
-									"drug_reference_identifier": "8756456",
-									"prescribed_cumulative_drug_dose": 87,
-									"actual_cumulative_drug_dose": 101
-								}
-							],
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_15",
+										"date_of_followup": "2022-08",
+										"disease_status_at_followup": "Partial remission",
+										"relapse_type": "Biochemical progression",
+										"date_of_relapse": "2022-02",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C16",
+										"recurrence_tumour_staging_system": "Durie-Salmon staging system",
+										"recurrence_t_category": "T2a",
+										"recurrence_n_category": "N2",
+										"recurrence_m_category": "M1c",
+										"recurrence_stage_group": "Stage A",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [
+							{
+								"er_status": "Cannot be determined",
+								"pr_status": "Negative",
+								"her2_ihc_status": "Unknown",
+								"her2_ish_status": "Not applicable",
+								"hpv_ihc_status": "Not applicable",
+								"hpv_pcr_status": "Positive",
+								"hpv_strain": [
+									"HPV35"
+								],
+								"test_interval": 6,
+								"psa_level": 304,
+								"ca125": 111,
+								"cea": 9,
+								"er_percent_positive": 1.3,
+								"pr_percent_positive": 15.1
+							}
+						],
+						"followups": []
+					},
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_5",
+						"date_of_diagnosis": "2019-02",
+						"cancer_type_code": "C02.1",
+						"basis_of_diagnosis": "Clinical",
+						"lymph_nodes_examined_status": "Yes",
+						"lymph_nodes_examined_method": "Physical palpation of patient",
+						"number_lymph_nodes_positive": 15,
+						"clinical_tumour_staging_system": "Ann Arbor staging system",
+						"clinical_t_category": "T4",
+						"clinical_n_category": "N3b",
+						"clinical_m_category": "M1d(1)",
+						"clinical_stage_group": "Stage IAS",
+						"laterality": "Left",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_11",
+								"pathological_tumour_staging_system": "AJCC 6th edition",
+								"pathological_t_category": "T1b(s)",
+								"pathological_n_category": "N3c",
+								"pathological_m_category": "M1",
+								"pathological_stage_group": "Stage II bulky",
+								"specimen_collection_date": "2021-10-26",
+								"specimen_storage": "Frozen in liquid nitrogen",
+								"tumour_histological_type": "8980/9",
+								"specimen_anatomic_location": "C43.1",
+								"reference_pathology_confirmed_diagnosis": "Not done",
+								"reference_pathology_confirmed_tumour_presence": "Unknown",
+								"tumour_grading_system": "Gleason grade group system",
+								"tumour_grade": "Grade 4",
+								"percent_tumour_cells_range": "0-19%",
+								"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
+								"specimen_processing": "Fresh",
+								"specimen_laterality": "Not applicable",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_17",
+										"specimen_tissue_source": "Pancreatic fluid",
+										"tumour_normal_designation": "Normal",
+										"specimen_type": "Metastatic tumour - additional metastatic",
+										"sample_type": "Total DNA"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_11",
+								"is_primary_treatment": "Yes",
+								"treatment_start_date": "2021-11",
+								"treatment_end_date": "2022-06",
+								"treatment_setting": "Induction",
+								"treatment_intent": "Curative",
+								"days_per_cycle": 4,
+								"number_of_cycles": 5,
+								"line_of_treatment": 1,
+								"status_of_treatment": "Treatment stopped due to acute toxicity",
+								"treatment_type": [
+									"Hormonal therapy",
+									"Other targeting molecular therapy",
+									"Surgery"
+								],
+								"response_to_treatment_criteria_method": "RECIST 1.1",
+								"response_to_treatment": "Physician assessed stable disease",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [],
+								"radiation": {
+									"radiation_therapy_modality": "Teleradiotherapy neutrons (procedure)",
+									"radiation_therapy_type": "External",
+									"anatomical_site_irradiated": "Left Scapula",
+									"radiation_therapy_fractions": 35,
+									"radiation_therapy_dosage": 70,
+									"radiation_boost": true,
+									"reference_radiation_treatment_id": "REFERENCE_RADIATION_TREATMENT_3"
+								},
 
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_23",
-									"date_of_followup": "2022-09",
-									"disease_status_at_followup": "Complete remission",
-									"relapse_type": "Local recurrence and distant metastasis",
-									"date_of_relapse": "2021-12",
-									"method_of_progression_status": [],
-									"anatomic_site_progression_or_recurrence": "C09",
-									"recurrence_tumour_staging_system": "International Neuroblastoma Staging System",
-									"recurrence_t_category": "Tis pd",
-									"recurrence_n_category": "N3",
-									"recurrence_m_category": "M1b",
-									"recurrence_stage_group": "Stage IB1",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				}
-			],
-			"comorbidities": [
-				{
-					"prior_malignancy": "Unknown",
-					"laterality_of_prior_malignancy": "Midline",
-					"comorbidity_type_code": "C03.9",
-					"comorbidity_treatment_status": "Yes",
-					"comorbidity_treatment": "Bone marrow transplant",
-					"age_at_comorbidity_diagnosis": 40
-				}
-			],
-			"exposures": [],
-			"biomarkers": [],
-			"followups": []
-		},
-		{
-			"submitter_donor_id": "DONOR_6",
-			"program_id": "SYNTHETIC-2",
-			"lost_to_followup_after_clinical_event_identifier": "",
-			"lost_to_followup_reason": "Discharged to palliative care",
-			"date_alive_after_lost_to_followup": "2022-08",
-			"is_deceased": false,
-			"cause_of_death": "Died of other reasons",
-			"date_of_birth": "1972-12",
-			"date_of_death": null,
-			"gender": "Non-binary",
-			"sex_at_birth": "Unknown",
-			"primary_site": [
-				"Hypopharynx",
-				"Nasal cavity and middle ear",
-				"Peripheral nerves and autonomic nervous system"
-			],
-			"primary_diagnoses": [
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_12",
-					"date_of_diagnosis": "2019-06",
-					"cancer_type_code": "C64.9",
-					"basis_of_diagnosis": "Unknown",
-					"lymph_nodes_examined_status": "Cannot be determined",
-					"lymph_nodes_examined_method": "Imaging",
-					"number_lymph_nodes_positive": 14,
-					"clinical_tumour_staging_system": "AJCC 7th edition",
-					"clinical_t_category": "T4b(s)",
-					"clinical_n_category": "N1c",
-					"clinical_m_category": "M1a",
-					"clinical_stage_group": "Stage IC",
-					"laterality": "Left",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_18",
-							"pathological_tumour_staging_system": "Binet staging system",
-							"pathological_t_category": "T1a1",
-							"pathological_n_category": "N3",
-							"pathological_m_category": "M1c(1)",
-							"pathological_stage_group": "In situ",
-							"specimen_collection_date": "2020-01-07",
-							"specimen_storage": "Unknown",
-							"tumour_histological_type": "8620/9",
-							"specimen_anatomic_location": "C43.9",
-							"reference_pathology_confirmed_diagnosis": "Not done",
-							"reference_pathology_confirmed_tumour_presence": "Yes",
-							"tumour_grading_system": "Four-tier grading system",
-							"tumour_grade": "High grade",
-							"percent_tumour_cells_range": "51-100%",
-							"percent_tumour_cells_measurement_method": "Unknown",
-							"specimen_processing": "Cryopreservation - other",
-							"specimen_laterality": "Right",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_24",
-									"specimen_tissue_source": "Synovial fluid",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Cell line - derived from metastatic tumour",
-									"sample_type": "polyA+ RNA"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_18",
-							"is_primary_treatment": "Yes",
-							"treatment_start_date": "2021-09",
-							"treatment_end_date": "2022-05",
-							"treatment_setting": "Induction",
-							"treatment_intent": "Preventive",
-							"days_per_cycle": 5,
-							"number_of_cycles": 4,
-							"line_of_treatment": 3,
-							"status_of_treatment": "Treatment stopped due to acute toxicity",
-							"treatment_type": [
-								"Photodynamic therapy",
-								"No treatment",
-								"Stem cell transplant"
-							],
-							"response_to_treatment_criteria_method": "Physician Assessed Response Criteria",
-							"response_to_treatment": "Primary refractory disease",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-							"surgery": {
-								"surgery_type": "Axillary lymph nodes sampling",
-								"surgery_site": "C14",
-								"surgery_location": "Primary",
-								"tumour_focality": "Unifocal",
-								"residual_tumour_classification": "R2",
-								"margin_types_involved": [
-									"Distal margin",
-									"Circumferential resection margin"
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_17",
+										"date_of_followup": "2022-10",
+										"disease_status_at_followup": "Progression not otherwise specified",
+										"relapse_type": "Biochemical progression",
+										"date_of_relapse": "2022-01",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C14",
+										"recurrence_tumour_staging_system": "AJCC 6th edition",
+										"recurrence_t_category": "T1a2",
+										"recurrence_n_category": "N0(mol-)",
+										"recurrence_m_category": "M1a(1)",
+										"recurrence_stage_group": "Stage IVAES",
+										"biomarkers": []
+									}
 								],
-								"margin_types_not_involved": [],
-								"margin_types_not_assessed": [
-									"Unknown"
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					},
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_6",
+						"date_of_diagnosis": "2019-10",
+						"cancer_type_code": "C43.1",
+						"basis_of_diagnosis": "Death certificate only",
+						"lymph_nodes_examined_status": "Not applicable",
+						"lymph_nodes_examined_method": "Physical palpation of patient",
+						"number_lymph_nodes_positive": 6,
+						"clinical_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
+						"clinical_t_category": "T2b",
+						"clinical_n_category": "N0a (biopsy)",
+						"clinical_m_category": "M0(i+)",
+						"clinical_stage_group": "Stage IIIC2",
+						"laterality": "Left",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_12",
+								"pathological_tumour_staging_system": "FIGO staging system",
+								"pathological_t_category": "Tis pd",
+								"pathological_n_category": "N1b",
+								"pathological_m_category": "M0(i+)",
+								"pathological_stage_group": "Stage IV",
+								"specimen_collection_date": "2020-07-07",
+								"specimen_storage": "Unknown",
+								"tumour_histological_type": "8962/1",
+								"specimen_anatomic_location": "C64.9",
+								"reference_pathology_confirmed_diagnosis": "Not done",
+								"reference_pathology_confirmed_tumour_presence": "No",
+								"tumour_grading_system": "Three-tier grading system",
+								"tumour_grade": "High",
+								"percent_tumour_cells_range": "0-19%",
+								"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
+								"specimen_processing": "Cryopreservation of live cells in liquid nitrogen",
+								"specimen_laterality": "Left",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_18",
+										"specimen_tissue_source": "Blood derived - bone marrow",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Cell line - derived from primary tumour",
+										"sample_type": "Other RNA fractions"
+									}
 								],
-								"lymphovascular_invasion": "Absent",
-								"perineural_invasion": "Absent",
-								"tumour_length": 9,
-								"tumour_width": 7,
-								"greatest_dimension_tumour": 5,
-								"submitter_specimen_id": "SPECIMEN_18"
-							},
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_24",
-									"date_of_followup": "2022-11",
-									"disease_status_at_followup": "Progression not otherwise specified",
-									"relapse_type": "Progression (liquid tumours)",
-									"date_of_relapse": "2022-05",
-									"method_of_progression_status": [
-										"Imaging (procedure)"
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_12",
+								"is_primary_treatment": "Unknown",
+								"treatment_start_date": "2021-08",
+								"treatment_end_date": "2022-11",
+								"treatment_setting": "Mobilization",
+								"treatment_intent": "Forensic",
+								"days_per_cycle": 2,
+								"number_of_cycles": 5,
+								"line_of_treatment": 5,
+								"status_of_treatment": "Physician decision (stopped or interrupted treatment)",
+								"treatment_type": [
+									"Other targeting molecular therapy",
+									"Surgery"
+								],
+								"response_to_treatment_criteria_method": "Physician Assessed Response Criteria",
+								"response_to_treatment": "Partial remission",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [],
+								"radiation": {
+									"radiation_therapy_modality": "Megavoltage radiation therapy using photons (procedure)",
+									"radiation_therapy_type": "Internal",
+									"anatomical_site_irradiated": "Right Adrenal",
+									"radiation_therapy_fractions": 30,
+									"radiation_therapy_dosage": 70,
+									"radiation_boost": false,
+									"reference_radiation_treatment_id": ""
+								},
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_18",
+										"date_of_followup": "2022-10",
+										"disease_status_at_followup": "Distant progression",
+										"relapse_type": "Progression (liquid tumours)",
+										"date_of_relapse": "2022-04",
+										"method_of_progression_status": [
+											"Histopathology test (procedure)",
+											"Imaging (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C20",
+										"recurrence_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
+										"recurrence_t_category": "T1c",
+										"recurrence_n_category": "N2b",
+										"recurrence_m_category": "M1c(0)",
+										"recurrence_stage_group": "Stage IIIC1",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					}
+				],
+				"comorbidities": [
+					{
+						"prior_malignancy": "Unknown",
+						"laterality_of_prior_malignancy": "Left",
+						"comorbidity_type_code": "C04.0",
+						"comorbidity_treatment_status": "Yes",
+						"comorbidity_treatment": "Other targeting molecular therapy",
+						"age_at_comorbidity_diagnosis": 57
+					},
+					{
+						"prior_malignancy": "No",
+						"laterality_of_prior_malignancy": "Midline",
+						"comorbidity_type_code": "C34.9",
+						"comorbidity_treatment_status": "Unknown",
+						"comorbidity_treatment": "Endoscopic therapy",
+						"age_at_comorbidity_diagnosis": 56
+					},
+					{
+						"prior_malignancy": "Yes",
+						"laterality_of_prior_malignancy": "Bilateral",
+						"comorbidity_type_code": "C50.9",
+						"comorbidity_treatment_status": "No",
+						"comorbidity_treatment": "Surgery",
+						"age_at_comorbidity_diagnosis": 53
+					}
+				],
+				"exposures": [
+					{
+						"tobacco_smoking_status": "Current reformed smoker for > 15 years",
+						"tobacco_type": [
+							"Cigarettes",
+							"Electronic cigarettes"
+						],
+						"pack_years_smoked": 90.0
+					},
+					{
+						"tobacco_smoking_status": "Current smoker",
+						"tobacco_type": [
+							"Cigarettes",
+							"Snuff"
+						],
+						"pack_years_smoked": 266.0
+					}
+				],
+				"biomarkers": [],
+				"followups": []
+			},
+			{
+				"submitter_donor_id": "DONOR_3",
+				"program_id": "SYNTHETIC-2",
+				"lost_to_followup_after_clinical_event_identifier": "",
+				"lost_to_followup_reason": "Discharged to palliative care",
+				"date_alive_after_lost_to_followup": "2022-01",
+				"is_deceased": true,
+				"cause_of_death": "Unknown",
+				"date_of_birth": "2005-08",
+				"date_of_death": "2011-08",
+				"gender": "Non-binary",
+				"sex_at_birth": "Female",
+				"primary_site": [
+					"Penis"
+				],
+				"primary_diagnoses": [
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_7",
+						"date_of_diagnosis": "2019-09",
+						"cancer_type_code": "C05.1",
+						"basis_of_diagnosis": "Death certificate only",
+						"lymph_nodes_examined_status": "Yes",
+						"lymph_nodes_examined_method": "Imaging",
+						"number_lymph_nodes_positive": 9,
+						"clinical_tumour_staging_system": "Ann Arbor staging system",
+						"clinical_t_category": "Tis(Paget)",
+						"clinical_n_category": "N3b",
+						"clinical_m_category": "M1a",
+						"clinical_stage_group": "Stage IIIES",
+						"laterality": "Right",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_13",
+								"pathological_tumour_staging_system": "AJCC 8th edition",
+								"pathological_t_category": "T1a(m)",
+								"pathological_n_category": "N3b",
+								"pathological_m_category": "M1b(0)",
+								"pathological_stage_group": "Stage A",
+								"specimen_collection_date": "2020-05-06",
+								"specimen_storage": "RNA later frozen",
+								"tumour_histological_type": "8124/9",
+								"specimen_anatomic_location": "C64.9",
+								"reference_pathology_confirmed_diagnosis": "Not done",
+								"reference_pathology_confirmed_tumour_presence": "Unknown",
+								"tumour_grading_system": "IASLC grading system",
+								"tumour_grade": "Grade Group 3",
+								"percent_tumour_cells_range": "20-50%",
+								"percent_tumour_cells_measurement_method": "Image analysis",
+								"specimen_processing": "Unknown",
+								"specimen_laterality": "Not applicable",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_19",
+										"specimen_tissue_source": "Solid tissue",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Metastatic tumour",
+										"sample_type": "Other RNA fractions"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_13",
+								"is_primary_treatment": "No",
+								"treatment_start_date": "2021-03",
+								"treatment_end_date": "2022-09",
+								"treatment_setting": "Mobilization",
+								"treatment_intent": "Guidance",
+								"days_per_cycle": 6,
+								"number_of_cycles": 5,
+								"line_of_treatment": 4,
+								"status_of_treatment": "Treatment incomplete due to technical or organizational problems",
+								"treatment_type": [
+									"Chemotherapy",
+									"Stem cell transplant",
+									"Bone marrow transplant"
+								],
+								"response_to_treatment_criteria_method": "Physician Assessed Response Criteria",
+								"response_to_treatment": "Partial remission",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [],
+								"radiation": {
+									"radiation_therapy_modality": "Brachytherapy (procedure)",
+									"radiation_therapy_type": "External",
+									"anatomical_site_irradiated": "Bilateral Ovary",
+									"radiation_therapy_fractions": 30,
+									"radiation_therapy_dosage": 66,
+									"radiation_boost": false,
+									"reference_radiation_treatment_id": ""
+								},
+
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_19",
+										"date_of_followup": "2022-09",
+										"disease_status_at_followup": "Complete remission",
+										"relapse_type": "Progression (liquid tumours)",
+										"date_of_relapse": "2022-01",
+										"method_of_progression_status": [
+											"Histopathology test (procedure)",
+											"Laboratory data interpretation (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C14",
+										"recurrence_tumour_staging_system": "International Neuroblastoma Staging System",
+										"recurrence_t_category": "T2a2",
+										"recurrence_n_category": "N3",
+										"recurrence_m_category": "M0",
+										"recurrence_stage_group": "Stage IAS",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					},
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_8",
+						"date_of_diagnosis": "2019-05",
+						"cancer_type_code": "C43.1",
+						"basis_of_diagnosis": "Clinical investigation",
+						"lymph_nodes_examined_status": "No",
+						"lymph_nodes_examined_method": "Lymph node dissection/pathological exam",
+						"number_lymph_nodes_positive": 7,
+						"clinical_tumour_staging_system": "FIGO staging system",
+						"clinical_t_category": "T3a",
+						"clinical_n_category": "N4",
+						"clinical_m_category": "M0",
+						"clinical_stage_group": "Stage IIS",
+						"laterality": "Bilateral",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_14",
+								"pathological_tumour_staging_system": "SEER staging system",
+								"pathological_t_category": "T4c",
+								"pathological_n_category": "N1a(sn)",
+								"pathological_m_category": "M1b(0)",
+								"pathological_stage_group": "Stage IAB",
+								"specimen_collection_date": "2021-11-26",
+								"specimen_storage": "Other",
+								"tumour_histological_type": "8289/9",
+								"specimen_anatomic_location": "C43.9",
+								"reference_pathology_confirmed_diagnosis": "Not done",
+								"reference_pathology_confirmed_tumour_presence": "No",
+								"tumour_grading_system": "FNCLCC grading system",
+								"tumour_grade": "High grade",
+								"percent_tumour_cells_range": "51-100%",
+								"percent_tumour_cells_measurement_method": "Unknown",
+								"specimen_processing": "Unknown",
+								"specimen_laterality": "Unknown",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_20",
+										"specimen_tissue_source": "Sputum",
+										"tumour_normal_designation": "Normal",
+										"specimen_type": "Normal",
+										"sample_type": "Protein"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_14",
+								"is_primary_treatment": "No",
+								"treatment_start_date": "2021-09",
+								"treatment_end_date": "2022-11",
+								"treatment_setting": "Preventative",
+								"treatment_intent": "Palliative",
+								"days_per_cycle": 2,
+								"number_of_cycles": 4,
+								"line_of_treatment": 3,
+								"status_of_treatment": "Treatment stopped due to lack of efficacy (disease progression)",
+								"treatment_type": [
+									"Chemotherapy",
+									"Immunotherapy",
+									"Stem cell transplant"
+								],
+								"response_to_treatment_criteria_method": "RECIST 1.1",
+								"response_to_treatment": "Immune complete response (iCR)",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [
+									{
+										"immunotherapy_type": "Cell-based",
+										"drug_reference_database": "RxNorm",
+										"immunotherapy_drug_dose_units": "IU/kg",
+										"drug_name": "Pembrolizumab",
+										"drug_reference_identifier": "4459876",
+										"prescribed_cumulative_drug_dose": 95,
+										"actual_cumulative_drug_dose": 160
+									},
+									{
+										"immunotherapy_type": "Other immunomodulatory substances",
+										"drug_reference_database": "PubChem",
+										"immunotherapy_drug_dose_units": "ug/m2",
+										"drug_name": "Pexidartinib",
+										"drug_reference_identifier": "8836851",
+										"prescribed_cumulative_drug_dose": 197,
+										"actual_cumulative_drug_dose": 183
+									},
+									{
+										"immunotherapy_type": "Monoclonal antibodies other than immune checkpoint inhibitors",
+										"drug_reference_database": "RxNorm",
+										"immunotherapy_drug_dose_units": "cells/kg",
+										"drug_name": "Copanlisib",
+										"drug_reference_identifier": "278936",
+										"prescribed_cumulative_drug_dose": 183,
+										"actual_cumulative_drug_dose": 100
+									}
+								],
+
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_20",
+										"date_of_followup": "2022-11",
+										"disease_status_at_followup": "Distant progression",
+										"relapse_type": "Local recurrence and distant metastasis",
+										"date_of_relapse": "2022-09",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C20",
+										"recurrence_tumour_staging_system": "AJCC 8th edition",
+										"recurrence_t_category": "T3a",
+										"recurrence_n_category": "N0(i-)",
+										"recurrence_m_category": "M1b(0)",
+										"recurrence_stage_group": "Stage IVBE",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					}
+				],
+				"comorbidities": [
+					{
+						"prior_malignancy": "Yes",
+						"laterality_of_prior_malignancy": "Bilateral",
+						"comorbidity_type_code": "C67.6",
+						"comorbidity_treatment_status": "Unknown",
+						"comorbidity_treatment": "Ablation",
+						"age_at_comorbidity_diagnosis": 41
+					},
+					{
+						"prior_malignancy": "No",
+						"laterality_of_prior_malignancy": "Left",
+						"comorbidity_type_code": "C43.9",
+						"comorbidity_treatment_status": "Unknown",
+						"comorbidity_treatment": "Endoscopic therapy",
+						"age_at_comorbidity_diagnosis": 46
+					}
+				],
+				"exposures": [
+					{
+						"tobacco_smoking_status": "Current reformed smoker for > 15 years",
+						"tobacco_type": [
+							"Waterpipe",
+							"Unknown"
+						],
+						"pack_years_smoked": 29.0
+					}
+				],
+				"biomarkers": [
+					{
+						"er_status": "Cannot be determined",
+						"pr_status": "Unknown",
+						"her2_ihc_status": "Not applicable",
+						"her2_ish_status": "Cannot be determined",
+						"hpv_ihc_status": "Negative",
+						"hpv_pcr_status": "Cannot be determined",
+						"hpv_strain": [
+							"HPV39",
+							"HPV16"
+						],
+						"test_interval": 4,
+						"psa_level": 245,
+						"ca125": 46,
+						"cea": 11,
+						"er_percent_positive": 59.9,
+						"pr_percent_positive": 39.7
+					}
+				],
+				"followups": []
+			},
+			{
+				"submitter_donor_id": "DONOR_4",
+				"program_id": "SYNTHETIC-2",
+				"lost_to_followup_after_clinical_event_identifier": "",
+				"lost_to_followup_reason": "Withdrew from study",
+				"date_alive_after_lost_to_followup": "2022-04",
+				"is_deceased": false,
+				"cause_of_death": "Died of cancer",
+				"date_of_birth": "1984-10",
+				"date_of_death": null,
+				"gender": "Man",
+				"sex_at_birth": "Male",
+				"primary_site": [
+					"Skin",
+					"Bronchus and lung",
+					"Prostate gland"
+				],
+				"primary_diagnoses": [
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_10",
+						"date_of_diagnosis": "2019-05",
+						"cancer_type_code": "C43.9",
+						"basis_of_diagnosis": "Cytology",
+						"lymph_nodes_examined_status": "Cannot be determined",
+						"lymph_nodes_examined_method": "Lymph node dissection/pathological exam",
+						"number_lymph_nodes_positive": 4,
+						"clinical_tumour_staging_system": "International Neuroblastoma Staging System",
+						"clinical_t_category": "Tis(Paget)",
+						"clinical_n_category": "N2a",
+						"clinical_m_category": "M1e",
+						"clinical_stage_group": "Stage Ms",
+						"laterality": "Left",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_16",
+								"pathological_tumour_staging_system": "Revised International staging system (RISS)",
+								"pathological_t_category": "T2(m)",
+								"pathological_n_category": "N1a(sn)",
+								"pathological_m_category": "M1c",
+								"pathological_stage_group": "Stage IIBE",
+								"specimen_collection_date": "2020-07-14",
+								"specimen_storage": "Frozen in vapour phase",
+								"tumour_histological_type": "8240/1",
+								"specimen_anatomic_location": "C67.6",
+								"reference_pathology_confirmed_diagnosis": "Not done",
+								"reference_pathology_confirmed_tumour_presence": "Not done",
+								"tumour_grading_system": "Scarff-Bloom-Richardson grading system",
+								"tumour_grade": "Grade 2",
+								"percent_tumour_cells_range": "20-50%",
+								"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
+								"specimen_processing": "Cryopreservation in dry ice (dead tissue)",
+								"specimen_laterality": "Unknown",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_22",
+										"specimen_tissue_source": "Cervical mucus",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Primary tumour - additional new primary",
+										"sample_type": "ctDNA"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_16",
+								"is_primary_treatment": "Yes",
+								"treatment_start_date": "2021-01",
+								"treatment_end_date": "2022-04",
+								"treatment_setting": "Conditioning",
+								"treatment_intent": "Diagnostic",
+								"days_per_cycle": 2,
+								"number_of_cycles": 4,
+								"line_of_treatment": 5,
+								"status_of_treatment": "Patient choice (stopped or interrupted treatment)",
+								"treatment_type": [
+									"Bone marrow transplant",
+									"Surgery",
+									"Radiation therapy"
+								],
+								"response_to_treatment_criteria_method": "iRECIST",
+								"response_to_treatment": "Physician assessed partial response",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [
+									{
+										"immunotherapy_type": "Monoclonal antibodies other than immune checkpoint inhibitors",
+										"drug_reference_database": "RxNorm",
+										"immunotherapy_drug_dose_units": "IU/kg",
+										"drug_name": "Copanlisib",
+										"drug_reference_identifier": "239766",
+										"prescribed_cumulative_drug_dose": 181,
+										"actual_cumulative_drug_dose": 111
+									}
+								],
+
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_22",
+										"date_of_followup": "2022-10",
+										"disease_status_at_followup": "Stable",
+										"relapse_type": "Distant recurrence/metastasis",
+										"date_of_relapse": "2021-11",
+										"method_of_progression_status": [
+											"Tumor marker measurement (procedure)",
+											"Physical examination procedure (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C18",
+										"recurrence_tumour_staging_system": "Binet staging system",
+										"recurrence_t_category": "T1a(s)",
+										"recurrence_n_category": "N0a (biopsy)",
+										"recurrence_m_category": "M1e",
+										"recurrence_stage_group": "Stage IIBES",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					},
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_9",
+						"date_of_diagnosis": "2019-06",
+						"cancer_type_code": "C04.9",
+						"basis_of_diagnosis": "Clinical",
+						"lymph_nodes_examined_status": "No lymph nodes found in resected specimen",
+						"lymph_nodes_examined_method": "Imaging",
+						"number_lymph_nodes_positive": 15,
+						"clinical_tumour_staging_system": "AJCC 7th edition",
+						"clinical_t_category": "T1a2",
+						"clinical_n_category": "N2c",
+						"clinical_m_category": "M1a(0)",
+						"clinical_stage_group": "Stage IIIBES",
+						"laterality": "Unilateral, side not specified",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_15",
+								"pathological_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
+								"pathological_t_category": "T1b(s)",
+								"pathological_n_category": "N4",
+								"pathological_m_category": "M1c",
+								"pathological_stage_group": "Stage IVB",
+								"specimen_collection_date": "2020-05-31",
+								"specimen_storage": "RNA later frozen",
+								"tumour_histological_type": "8250/3",
+								"specimen_anatomic_location": "C43.9",
+								"reference_pathology_confirmed_diagnosis": "Yes",
+								"reference_pathology_confirmed_tumour_presence": "Not done",
+								"tumour_grading_system": "Grading system for GNETs",
+								"tumour_grade": "High",
+								"percent_tumour_cells_range": "0-19%",
+								"percent_tumour_cells_measurement_method": "Pathology estimate by percent nuclei",
+								"specimen_processing": "Cryopreservation of live cells in liquid nitrogen",
+								"specimen_laterality": "Not applicable",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_21",
+										"specimen_tissue_source": "Buccal cell",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Recurrent tumour",
+										"sample_type": "Protein"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_15",
+								"is_primary_treatment": "Yes",
+								"treatment_start_date": "2021-12",
+								"treatment_end_date": "2022-07",
+								"treatment_setting": "Locally advanced",
+								"treatment_intent": "Guidance",
+								"days_per_cycle": 5,
+								"number_of_cycles": 3,
+								"line_of_treatment": 2,
+								"status_of_treatment": "Treatment stopped due to lack of efficacy (disease progression)",
+								"treatment_type": [
+									"Stem cell transplant",
+									"Immunotherapy",
+									"Hormonal therapy"
+								],
+								"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
+								"response_to_treatment": "Complete remission with incomplete hematologic recovery (CRi)",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [
+									{
+										"immunotherapy_type": "Cell-based",
+										"drug_reference_database": "NCI Thesaurus",
+										"immunotherapy_drug_dose_units": "IU/kg",
+										"drug_name": "Necitumumab",
+										"drug_reference_identifier": "278936",
+										"prescribed_cumulative_drug_dose": 138,
+										"actual_cumulative_drug_dose": 167
+									},
+									{
+										"immunotherapy_type": "Immune checkpoint inhibitors",
+										"drug_reference_database": "PubChem",
+										"immunotherapy_drug_dose_units": "g/m2",
+										"drug_name": "Pexidartinib",
+										"drug_reference_identifier": "278936",
+										"prescribed_cumulative_drug_dose": 184,
+										"actual_cumulative_drug_dose": 190
+									}
+								],
+
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_21",
+										"disease_status_at_followup": "Loco-regional progression",
+										"relapse_type": "Progression (liquid tumours)",
+										"date_of_relapse": "2021-12",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C18",
+										"recurrence_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
+										"recurrence_t_category": "T4",
+										"recurrence_n_category": "N0a (biopsy)",
+										"recurrence_m_category": "M1",
+										"recurrence_stage_group": "Stage IB2",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					}
+				],
+				"comorbidities": [
+					{
+						"prior_malignancy": "No",
+						"laterality_of_prior_malignancy": "Unknown",
+						"comorbidity_type_code": "C67.6",
+						"comorbidity_treatment_status": "Unknown",
+						"comorbidity_treatment": "Radiation therapy",
+						"age_at_comorbidity_diagnosis": 47
+					},
+					{
+						"prior_malignancy": "No",
+						"laterality_of_prior_malignancy": "Unknown",
+						"comorbidity_type_code": "C02.0",
+						"comorbidity_treatment_status": "No",
+						"comorbidity_treatment": "Photodynamic therapy",
+						"age_at_comorbidity_diagnosis": 35
+					}
+				],
+				"exposures": [],
+				"biomarkers": [],
+				"followups": []
+			},
+			{
+				"submitter_donor_id": "DONOR_5",
+				"program_id": "SYNTHETIC-2",
+				"lost_to_followup_after_clinical_event_identifier": "",
+				"lost_to_followup_reason": "Completed study",
+				"date_alive_after_lost_to_followup": "2022-02",
+				"is_deceased": true,
+				"cause_of_death": "Died of other reasons",
+				"date_of_birth": "1998-08",
+				"date_of_death": "2013-08",
+				"gender": "Non-binary",
+				"sex_at_birth": "Other",
+				"primary_site": [
+					"Connective, subcutaneous and other soft tissues",
+					"Penis",
+					"Thyroid gland",
+					"Adrenal gland"
+				],
+				"primary_diagnoses": [
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_11",
+						"date_of_diagnosis": "2019-07",
+						"cancer_type_code": "C64.9",
+						"basis_of_diagnosis": "Specific tumour markers",
+						"lymph_nodes_examined_status": "Cannot be determined",
+						"lymph_nodes_examined_method": "Physical palpation of patient",
+						"number_lymph_nodes_positive": 15,
+						"clinical_tumour_staging_system": "Rai staging system",
+						"clinical_t_category": "T4b",
+						"clinical_n_category": "N0(i+)",
+						"clinical_m_category": "M1e",
+						"clinical_stage_group": "Stage IIBES",
+						"laterality": "Bilateral",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_17",
+								"pathological_tumour_staging_system": "AJCC 8th edition",
+								"pathological_t_category": "T4a(m)",
+								"pathological_n_category": "N0b",
+								"pathological_m_category": "M1c(0)",
+								"pathological_stage_group": "Stage IIIA2",
+								"specimen_collection_date": "2021-03-02",
+								"specimen_storage": "Frozen in -70 freezer",
+								"tumour_histological_type": "8970/3",
+								"specimen_anatomic_location": "C43.9",
+								"reference_pathology_confirmed_diagnosis": "Unknown",
+								"reference_pathology_confirmed_tumour_presence": "Yes",
+								"tumour_grading_system": "Grading system for GISTs",
+								"tumour_grade": "Grade 4",
+								"percent_tumour_cells_range": "0-19%",
+								"percent_tumour_cells_measurement_method": "Image analysis",
+								"specimen_processing": "Unknown",
+								"specimen_laterality": "Not applicable",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_23",
+										"specimen_tissue_source": "Pleural fluid",
+										"tumour_normal_designation": "Tumour",
+										"specimen_type": "Xenograft - derived from metastatic tumour",
+										"sample_type": "Other RNA fractions"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_17",
+								"is_primary_treatment": "Yes",
+								"treatment_start_date": "2021-02",
+								"treatment_end_date": "2022-06",
+								"treatment_setting": "Conditioning",
+								"treatment_intent": "Forensic",
+								"days_per_cycle": 6,
+								"number_of_cycles": 3,
+								"line_of_treatment": 1,
+								"status_of_treatment": "Treatment incomplete due to technical or organizational problems",
+								"treatment_type": [
+									"Immunotherapy",
+									"Surgery",
+									"No treatment"
+								],
+								"response_to_treatment_criteria_method": "RECIST 1.1",
+								"response_to_treatment": "Partial remission",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [
+									{
+										"immunotherapy_type": "Monoclonal antibodies other than immune checkpoint inhibitors",
+										"drug_reference_database": "NCI Thesaurus",
+										"immunotherapy_drug_dose_units": "IU/m2",
+										"drug_name": "Gilteritinib",
+										"drug_reference_identifier": "8756456",
+										"prescribed_cumulative_drug_dose": 87,
+										"actual_cumulative_drug_dose": 101
+									}
+								],
+
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_23",
+										"date_of_followup": "2022-09",
+										"disease_status_at_followup": "Complete remission",
+										"relapse_type": "Local recurrence and distant metastasis",
+										"date_of_relapse": "2021-12",
+										"method_of_progression_status": [],
+										"anatomic_site_progression_or_recurrence": "C09",
+										"recurrence_tumour_staging_system": "International Neuroblastoma Staging System",
+										"recurrence_t_category": "Tis pd",
+										"recurrence_n_category": "N3",
+										"recurrence_m_category": "M1b",
+										"recurrence_stage_group": "Stage IB1",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					}
+				],
+				"comorbidities": [
+					{
+						"prior_malignancy": "Unknown",
+						"laterality_of_prior_malignancy": "Midline",
+						"comorbidity_type_code": "C03.9",
+						"comorbidity_treatment_status": "Yes",
+						"comorbidity_treatment": "Bone marrow transplant",
+						"age_at_comorbidity_diagnosis": 40
+					}
+				],
+				"exposures": [],
+				"biomarkers": [],
+				"followups": []
+			},
+			{
+				"submitter_donor_id": "DONOR_6",
+				"program_id": "SYNTHETIC-2",
+				"lost_to_followup_after_clinical_event_identifier": "",
+				"lost_to_followup_reason": "Discharged to palliative care",
+				"date_alive_after_lost_to_followup": "2022-08",
+				"is_deceased": false,
+				"cause_of_death": "Died of other reasons",
+				"date_of_birth": "1972-12",
+				"date_of_death": null,
+				"gender": "Non-binary",
+				"sex_at_birth": "Unknown",
+				"primary_site": [
+					"Hypopharynx",
+					"Nasal cavity and middle ear",
+					"Peripheral nerves and autonomic nervous system"
+				],
+				"primary_diagnoses": [
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_12",
+						"date_of_diagnosis": "2019-06",
+						"cancer_type_code": "C64.9",
+						"basis_of_diagnosis": "Unknown",
+						"lymph_nodes_examined_status": "Cannot be determined",
+						"lymph_nodes_examined_method": "Imaging",
+						"number_lymph_nodes_positive": 14,
+						"clinical_tumour_staging_system": "AJCC 7th edition",
+						"clinical_t_category": "T4b(s)",
+						"clinical_n_category": "N1c",
+						"clinical_m_category": "M1a",
+						"clinical_stage_group": "Stage IC",
+						"laterality": "Left",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_18",
+								"pathological_tumour_staging_system": "Binet staging system",
+								"pathological_t_category": "T1a1",
+								"pathological_n_category": "N3",
+								"pathological_m_category": "M1c(1)",
+								"pathological_stage_group": "In situ",
+								"specimen_collection_date": "2020-01-07",
+								"specimen_storage": "Unknown",
+								"tumour_histological_type": "8620/9",
+								"specimen_anatomic_location": "C43.9",
+								"reference_pathology_confirmed_diagnosis": "Not done",
+								"reference_pathology_confirmed_tumour_presence": "Yes",
+								"tumour_grading_system": "Four-tier grading system",
+								"tumour_grade": "High grade",
+								"percent_tumour_cells_range": "51-100%",
+								"percent_tumour_cells_measurement_method": "Unknown",
+								"specimen_processing": "Cryopreservation - other",
+								"specimen_laterality": "Right",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_24",
+										"specimen_tissue_source": "Synovial fluid",
+										"tumour_normal_designation": "Normal",
+										"specimen_type": "Cell line - derived from metastatic tumour",
+										"sample_type": "polyA+ RNA"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_18",
+								"is_primary_treatment": "Yes",
+								"treatment_start_date": "2021-09",
+								"treatment_end_date": "2022-05",
+								"treatment_setting": "Induction",
+								"treatment_intent": "Preventive",
+								"days_per_cycle": 5,
+								"number_of_cycles": 4,
+								"line_of_treatment": 3,
+								"status_of_treatment": "Treatment stopped due to acute toxicity",
+								"treatment_type": [
+									"Photodynamic therapy",
+									"No treatment",
+									"Stem cell transplant"
+								],
+								"response_to_treatment_criteria_method": "Physician Assessed Response Criteria",
+								"response_to_treatment": "Primary refractory disease",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [],
+								"surgery": {
+									"surgery_type": "Axillary lymph nodes sampling",
+									"surgery_site": "C14",
+									"surgery_location": "Primary",
+									"tumour_focality": "Unifocal",
+									"residual_tumour_classification": "R2",
+									"margin_types_involved": [
+										"Distal margin",
+										"Circumferential resection margin"
 									],
-									"anatomic_site_progression_or_recurrence": "C13",
-									"recurrence_tumour_staging_system": "Lugano staging system",
-									"recurrence_t_category": "TX",
-									"recurrence_n_category": "N0(mol-)",
-									"recurrence_m_category": "M1d(0)",
-									"recurrence_stage_group": "Stage IA1",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				}
-			],
-			"comorbidities": [
-				{
-					"prior_malignancy": "No",
-					"laterality_of_prior_malignancy": "Left",
-					"comorbidity_type_code": "C02.1",
-					"comorbidity_treatment_status": "Unknown",
-					"comorbidity_treatment": "Ablation",
-					"age_at_comorbidity_diagnosis": 51
-				}
-			],
-			"exposures": [],
-			"biomarkers": [],
-			"followups": []
-		},
-		{
-			"submitter_donor_id": "DONOR_7",
-			"program_id": "SYNTHETIC-2",
-			"lost_to_followup_after_clinical_event_identifier": "",
-			"lost_to_followup_reason": "Lost contact",
-			"date_alive_after_lost_to_followup": "2022-10",
-			"is_deceased": false,
-			"cause_of_death": "Unknown",
-			"date_of_birth": "1961-05",
-			"date_of_death": null,
-			"gender": "Non-binary",
-			"sex_at_birth": "Male",
-			"primary_site": [
-				"Floor of mouth"
-			],
-			"primary_diagnoses": [
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_13",
-					"date_of_diagnosis": "2019-10",
-					"cancer_type_code": "C02.2",
-					"basis_of_diagnosis": "Death certificate only",
-					"lymph_nodes_examined_status": "Yes",
-					"lymph_nodes_examined_method": "Physical palpation of patient",
-					"number_lymph_nodes_positive": 10,
-					"clinical_tumour_staging_system": "Revised International staging system (RISS)",
-					"clinical_t_category": "T2a1",
-					"clinical_n_category": "N0b",
-					"clinical_m_category": "M1c",
-					"clinical_stage_group": "Stage IEA",
-					"laterality": "Unilateral, side not specified",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_19",
-							"pathological_tumour_staging_system": "Rai staging system",
-							"pathological_t_category": "T2a1",
-							"pathological_n_category": "N3c",
-							"pathological_m_category": "M1d(1)",
-							"pathological_stage_group": "Stage IIIA",
-							"specimen_collection_date": "2020-03-02",
-							"specimen_storage": "Unknown",
-							"tumour_histological_type": "8289/9",
-							"specimen_anatomic_location": "C15.9",
-							"reference_pathology_confirmed_diagnosis": "Not done",
-							"reference_pathology_confirmed_tumour_presence": "Unknown",
-							"tumour_grading_system": "FNCLCC grading system",
-							"tumour_grade": "G1",
-							"percent_tumour_cells_range": "0-19%",
-							"percent_tumour_cells_measurement_method": "Genomics",
-							"specimen_processing": "Cryopreservation - other",
-							"specimen_laterality": "Not applicable",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_25",
-									"specimen_tissue_source": "Pancreatic fluid",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Metastatic tumour - metastasis to distant location",
-									"sample_type": "Protein"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_19",
-							"is_primary_treatment": "Yes",
-							"treatment_start_date": "2021-07",
-							"treatment_end_date": "2022-01",
-							"treatment_setting": "Radiosensitization",
-							"treatment_intent": "Diagnostic",
-							"days_per_cycle": 4,
-							"number_of_cycles": 4,
-							"line_of_treatment": 5,
-							"status_of_treatment": "Treatment completed as prescribed",
-							"treatment_type": [
-								"Stem cell transplant"
-							],
-							"response_to_treatment_criteria_method": "Cheson CLL 2012 Oncology Response Criteria",
-							"response_to_treatment": "Complete remission without measurable residual disease (CR MRD-)",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-							"surgery": {
-								"surgery_type": "Axillary Clearance",
-								"surgery_site": "C14",
-								"surgery_location": "Local recurrence",
-								"tumour_focality": "Unknown",
-								"residual_tumour_classification": "Unknown",
-								"margin_types_involved": [],
-								"margin_types_not_involved": [],
-								"margin_types_not_assessed": [
-									"Circumferential resection margin",
-									"Proximal margin"
-								],
-								"lymphovascular_invasion": "Venous (large vessel) invasion only",
-								"perineural_invasion": "Unknown",
-								"tumour_length": 5,
-								"tumour_width": 5,
-								"greatest_dimension_tumour": 6,
-								"submitter_specimen_id": null
-							},
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_25",
-									"date_of_followup": "2022-11",
-									"disease_status_at_followup": "Relapse or recurrence",
-									"relapse_type": "Biochemical progression",
-									"date_of_relapse": "2022-03",
-									"method_of_progression_status": [
-										"Physical examination procedure (procedure)"
+									"margin_types_not_involved": [],
+									"margin_types_not_assessed": [
+										"Unknown"
 									],
-									"anatomic_site_progression_or_recurrence": "C15",
-									"recurrence_tumour_staging_system": "AJCC 7th edition",
-									"recurrence_t_category": "Tis(LAMN)",
-									"recurrence_n_category": "N2a",
-									"recurrence_m_category": "M1d(1)",
-									"recurrence_stage_group": "Stage IIIA",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				}
-			],
-			"comorbidities": [
-				{
-					"prior_malignancy": "No",
-					"laterality_of_prior_malignancy": "Bilateral",
-					"comorbidity_type_code": "C67.6",
-					"comorbidity_treatment_status": "Unknown",
-					"comorbidity_treatment": "Radiation therapy",
-					"age_at_comorbidity_diagnosis": 38
-				}
-			],
-			"exposures": [
-				{
-					"tobacco_smoking_status": "Current reformed smoker, duration not specified",
-					"tobacco_type": [
-						"Unknown",
-						"Electronic cigarettes",
-						"Not applicable"
-					],
-					"pack_years_smoked": 104.0
-				}
-			],
-			"biomarkers": [],
-			"followups": []
-		},
-		{
-			"submitter_donor_id": "DONOR_8",
-			"program_id": "SYNTHETIC-2",
-			"lost_to_followup_after_clinical_event_identifier": "",
-			"lost_to_followup_reason": "Discharged to palliative care",
-			"date_alive_after_lost_to_followup": "2022-03",
-			"is_deceased": false,
-			"cause_of_death": "Died of cancer",
-			"date_of_birth": "2003-12",
-			"date_of_death": null,
-			"gender": "Woman",
-			"sex_at_birth": "Unknown",
-			"primary_site": [
-				"Hypopharynx",
-				"Thymus",
-				"Esophagus",
-				"Colon"
-			],
-			"primary_diagnoses": [
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_14",
-					"date_of_diagnosis": "2019-07",
-					"cancer_type_code": "C02.1",
-					"basis_of_diagnosis": "Death certificate only",
-					"lymph_nodes_examined_status": "No lymph nodes found in resected specimen",
-					"lymph_nodes_examined_method": "Lymph node dissection/pathological exam",
-					"number_lymph_nodes_positive": 13,
-					"clinical_tumour_staging_system": "AJCC 6th edition",
-					"clinical_t_category": "T2(s)",
-					"clinical_n_category": "N1a",
-					"clinical_m_category": "M0",
-					"clinical_stage_group": "Regionalized",
-					"laterality": "Left",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_20",
-							"pathological_tumour_staging_system": "Durie-Salmon staging system",
-							"pathological_t_category": "T1b",
-							"pathological_n_category": "N0(mol+)",
-							"pathological_m_category": "M0(i+)",
-							"pathological_stage_group": "Stage IIIB",
-							"specimen_collection_date": "2021-02-23",
-							"specimen_storage": "RNA later frozen",
-							"tumour_histological_type": "8063/1",
-							"specimen_anatomic_location": "C15.9",
-							"reference_pathology_confirmed_diagnosis": "Not done",
-							"reference_pathology_confirmed_tumour_presence": "Not done",
-							"tumour_grading_system": "Grading system for GISTs",
-							"tumour_grade": "Grade IV",
-							"percent_tumour_cells_range": "0-19%",
-							"percent_tumour_cells_measurement_method": "Image analysis",
-							"specimen_processing": "Unknown",
-							"specimen_laterality": "Not applicable",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_26",
-									"specimen_tissue_source": "Bone marrow fluid",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Recurrent tumour",
-									"sample_type": "Total DNA"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_20",
-							"is_primary_treatment": "Yes",
-							"treatment_start_date": "2021-02",
-							"treatment_end_date": "2022-09",
-							"treatment_setting": "Locally advanced",
-							"treatment_intent": "Diagnostic",
-							"days_per_cycle": 4,
-							"number_of_cycles": 5,
-							"line_of_treatment": 1,
-							"status_of_treatment": "Treatment stopped due to lack of efficacy (disease progression)",
-							"treatment_type": [
-								"Other targeting molecular therapy",
-								"Photodynamic therapy",
-								"Chemotherapy"
-							],
-							"response_to_treatment_criteria_method": "Physician Assessed Response Criteria",
-							"response_to_treatment": "Minor response",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-							"surgery": {
-								"surgery_type": "Tumor Debulking",
-								"surgery_site": "C06",
-								"surgery_location": "Primary",
-								"tumour_focality": "Not applicable",
-								"residual_tumour_classification": "RX",
-								"margin_types_involved": [
-									"Unknown",
-									"Distal margin"
+									"lymphovascular_invasion": "Absent",
+									"perineural_invasion": "Absent",
+									"tumour_length": 9,
+									"tumour_width": 7,
+									"greatest_dimension_tumour": 5,
+									"submitter_specimen_id": "SPECIMEN_18"
+								},
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_24",
+										"date_of_followup": "2022-11",
+										"disease_status_at_followup": "Progression not otherwise specified",
+										"relapse_type": "Progression (liquid tumours)",
+										"date_of_relapse": "2022-05",
+										"method_of_progression_status": [
+											"Imaging (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C13",
+										"recurrence_tumour_staging_system": "Lugano staging system",
+										"recurrence_t_category": "TX",
+										"recurrence_n_category": "N0(mol-)",
+										"recurrence_m_category": "M1d(0)",
+										"recurrence_stage_group": "Stage IA1",
+										"biomarkers": []
+									}
 								],
-								"margin_types_not_involved": [],
-								"margin_types_not_assessed": [],
-								"lymphovascular_invasion": "Venous (large vessel) invasion only",
-								"perineural_invasion": "Present",
-								"tumour_length": 3,
-								"tumour_width": 6,
-								"greatest_dimension_tumour": 5,
-								"submitter_specimen_id": null
-							},
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_26",
-									"date_of_followup": "2022-10",
-									"disease_status_at_followup": "Distant progression",
-									"relapse_type": "Local recurrence",
-									"date_of_relapse": "2022-10",
-									"method_of_progression_status": [
-										"Physical examination procedure (procedure)",
-										"Assessment of symptom control (procedure)"
-									],
-									"anatomic_site_progression_or_recurrence": "C06",
-									"recurrence_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
-									"recurrence_t_category": "T2(s)",
-									"recurrence_n_category": "N3c",
-									"recurrence_m_category": "M1c",
-									"recurrence_stage_group": "Stage IIIS",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				}
-			],
-			"comorbidities": [
-				{
-					"prior_malignancy": "Yes",
-					"laterality_of_prior_malignancy": "Unknown",
-					"comorbidity_type_code": "C64.9",
-					"comorbidity_treatment_status": "Yes",
-					"comorbidity_treatment": "Surgery",
-					"age_at_comorbidity_diagnosis": 51
-				}
-			],
-			"exposures": [
-				{
-					"tobacco_smoking_status": "Current reformed smoker for > 15 years",
-					"tobacco_type": [
-						"Waterpipe",
-						"Unknown"
-					],
-					"pack_years_smoked": 48.0
-				}
-			],
-			"biomarkers": [],
-			"followups": []
-		},
-		{
-			"submitter_donor_id": "DONOR_9",
-			"program_id": "SYNTHETIC-2",
-			"lost_to_followup_after_clinical_event_identifier": "",
-			"lost_to_followup_reason": "Withdrew from study",
-			"date_alive_after_lost_to_followup": "2022-05",
-			"is_deceased": false,
-			"cause_of_death": "Died of other reasons",
-			"date_of_birth": "1993-10",
-			"date_of_death": null,
-			"gender": "Woman",
-			"sex_at_birth": "Female",
-			"primary_site": [
-				"Trachea",
-				"Other and ill-defined digestive organs"
-			],
-			"primary_diagnoses": [
-				{
-					"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_15",
-					"date_of_diagnosis": "2019-01",
-					"cancer_type_code": "C05.1",
-					"basis_of_diagnosis": "Specific tumour markers",
-					"lymph_nodes_examined_status": "Yes",
-					"lymph_nodes_examined_method": "Physical palpation of patient",
-					"number_lymph_nodes_positive": 15,
-					"clinical_tumour_staging_system": "International Neuroblastoma Staging System",
-					"clinical_t_category": "T3(s)",
-					"clinical_n_category": "N1b",
-					"clinical_m_category": "M1c(0)",
-					"clinical_stage_group": "Stage IIA",
-					"laterality": "Unilateral, side not specified",
-					"specimens": [
-						{
-							"submitter_specimen_id": "SPECIMEN_21",
-							"pathological_tumour_staging_system": "Durie-Salmon staging system",
-							"pathological_t_category": "Tis(DCIS)",
-							"pathological_n_category": "N2",
-							"pathological_m_category": "M1d(0)",
-							"pathological_stage_group": "Stage IIS",
-							"specimen_collection_date": "2020-12-07",
-							"specimen_storage": "Not Applicable",
-							"tumour_histological_type": "8630/9",
-							"specimen_anatomic_location": "C43.9",
-							"reference_pathology_confirmed_diagnosis": "Unknown",
-							"reference_pathology_confirmed_tumour_presence": "Not done",
-							"tumour_grading_system": "Four-tier grading system",
-							"tumour_grade": "High grade",
-							"percent_tumour_cells_range": "51-100%",
-							"percent_tumour_cells_measurement_method": "Unknown",
-							"specimen_processing": "Cryopreservation - other",
-							"specimen_laterality": "Left",
-							"sample_registrations": [
-								{
-									"submitter_sample_id": "SAMPLE_REGISTRATION_27",
-									"specimen_tissue_source": "Blood derived - peripheral blood",
-									"tumour_normal_designation": "Normal",
-									"specimen_type": "Normal",
-									"sample_type": "Protein"
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"treatments": [
-						{
-							"submitter_treatment_id": "TREATMENT_21",
-							"is_primary_treatment": "Unknown",
-							"treatment_start_date": "2021-03",
-							"treatment_end_date": "2022-10",
-							"treatment_setting": "Locally advanced",
-							"treatment_intent": "Forensic",
-							"days_per_cycle": 3,
-							"number_of_cycles": 3,
-							"line_of_treatment": 4,
-							"status_of_treatment": "Other",
-							"treatment_type": [
-								"Photodynamic therapy"
-							],
-							"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
-							"response_to_treatment": "Progressive disease",
-							"chemotherapies": [],
-							"hormone_therapies": [],
-							"immunotherapies": [],
-							"surgery": {
-								"surgery_type": "Pancreaticojejunostomy, side-to-side anastomosis",
-								"surgery_site": "C12",
-								"surgery_location": "Metastatic",
-								"tumour_focality": "Unknown",
-								"residual_tumour_classification": "R0",
-								"margin_types_involved": [],
-								"margin_types_not_involved": [
-									"Unknown"
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					}
+				],
+				"comorbidities": [
+					{
+						"prior_malignancy": "No",
+						"laterality_of_prior_malignancy": "Left",
+						"comorbidity_type_code": "C02.1",
+						"comorbidity_treatment_status": "Unknown",
+						"comorbidity_treatment": "Ablation",
+						"age_at_comorbidity_diagnosis": 51
+					}
+				],
+				"exposures": [],
+				"biomarkers": [],
+				"followups": []
+			},
+			{
+				"submitter_donor_id": "DONOR_7",
+				"program_id": "SYNTHETIC-2",
+				"lost_to_followup_after_clinical_event_identifier": "",
+				"lost_to_followup_reason": "Lost contact",
+				"date_alive_after_lost_to_followup": "2022-10",
+				"is_deceased": false,
+				"cause_of_death": "Unknown",
+				"date_of_birth": "1961-05",
+				"date_of_death": null,
+				"gender": "Non-binary",
+				"sex_at_birth": "Male",
+				"primary_site": [
+					"Floor of mouth"
+				],
+				"primary_diagnoses": [
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_13",
+						"date_of_diagnosis": "2019-10",
+						"cancer_type_code": "C02.2",
+						"basis_of_diagnosis": "Death certificate only",
+						"lymph_nodes_examined_status": "Yes",
+						"lymph_nodes_examined_method": "Physical palpation of patient",
+						"number_lymph_nodes_positive": 10,
+						"clinical_tumour_staging_system": "Revised International staging system (RISS)",
+						"clinical_t_category": "T2a1",
+						"clinical_n_category": "N0b",
+						"clinical_m_category": "M1c",
+						"clinical_stage_group": "Stage IEA",
+						"laterality": "Unilateral, side not specified",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_19",
+								"pathological_tumour_staging_system": "Rai staging system",
+								"pathological_t_category": "T2a1",
+								"pathological_n_category": "N3c",
+								"pathological_m_category": "M1d(1)",
+								"pathological_stage_group": "Stage IIIA",
+								"specimen_collection_date": "2020-03-02",
+								"specimen_storage": "Unknown",
+								"tumour_histological_type": "8289/9",
+								"specimen_anatomic_location": "C15.9",
+								"reference_pathology_confirmed_diagnosis": "Not done",
+								"reference_pathology_confirmed_tumour_presence": "Unknown",
+								"tumour_grading_system": "FNCLCC grading system",
+								"tumour_grade": "G1",
+								"percent_tumour_cells_range": "0-19%",
+								"percent_tumour_cells_measurement_method": "Genomics",
+								"specimen_processing": "Cryopreservation - other",
+								"specimen_laterality": "Not applicable",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_25",
+										"specimen_tissue_source": "Pancreatic fluid",
+										"tumour_normal_designation": "Normal",
+										"specimen_type": "Metastatic tumour - metastasis to distant location",
+										"sample_type": "Protein"
+									}
 								],
-								"margin_types_not_assessed": [],
-								"lymphovascular_invasion": "Venous (large vessel) invasion only",
-								"perineural_invasion": "Present",
-								"tumour_length": 6,
-								"tumour_width": 6,
-								"greatest_dimension_tumour": 6,
-								"submitter_specimen_id": null
-							},
-							"followups": [
-								{
-									"submitter_follow_up_id": "FOLLOW_UP_27",
-									"date_of_followup": "2022-08",
-									"disease_status_at_followup": "Stable",
-									"relapse_type": "Distant recurrence/metastasis",
-									"date_of_relapse": "2022-06",
-									"method_of_progression_status": [
-										"Laboratory data interpretation (procedure)",
-										"Histopathology test (procedure)"
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_19",
+								"is_primary_treatment": "Yes",
+								"treatment_start_date": "2021-07",
+								"treatment_end_date": "2022-01",
+								"treatment_setting": "Radiosensitization",
+								"treatment_intent": "Diagnostic",
+								"days_per_cycle": 4,
+								"number_of_cycles": 4,
+								"line_of_treatment": 5,
+								"status_of_treatment": "Treatment completed as prescribed",
+								"treatment_type": [
+									"Stem cell transplant"
+								],
+								"response_to_treatment_criteria_method": "Cheson CLL 2012 Oncology Response Criteria",
+								"response_to_treatment": "Complete remission without measurable residual disease (CR MRD-)",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [],
+								"surgery": {
+									"surgery_type": "Axillary Clearance",
+									"surgery_site": "C14",
+									"surgery_location": "Local recurrence",
+									"tumour_focality": "Unknown",
+									"residual_tumour_classification": "Unknown",
+									"margin_types_involved": [],
+									"margin_types_not_involved": [],
+									"margin_types_not_assessed": [
+										"Circumferential resection margin",
+										"Proximal margin"
 									],
-									"anatomic_site_progression_or_recurrence": "C08",
-									"recurrence_tumour_staging_system": "International Neuroblastoma Staging System",
-									"recurrence_t_category": "T3b",
-									"recurrence_n_category": "N0(i-)",
-									"recurrence_m_category": "M1c(0)",
-									"recurrence_stage_group": "Stage 0",
-									"biomarkers": []
-								}
-							],
-							"biomarkers": []
-						}
-					],
-					"biomarkers": [],
-					"followups": []
-				}
-			],
-			"comorbidities": [],
-			"exposures": [],
-			"biomarkers": [],
-			"followups": []
-		}
-]
+									"lymphovascular_invasion": "Venous (large vessel) invasion only",
+									"perineural_invasion": "Unknown",
+									"tumour_length": 5,
+									"tumour_width": 5,
+									"greatest_dimension_tumour": 6,
+									"submitter_specimen_id": null
+								},
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_25",
+										"date_of_followup": "2022-11",
+										"disease_status_at_followup": "Relapse or recurrence",
+										"relapse_type": "Biochemical progression",
+										"date_of_relapse": "2022-03",
+										"method_of_progression_status": [
+											"Physical examination procedure (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C15",
+										"recurrence_tumour_staging_system": "AJCC 7th edition",
+										"recurrence_t_category": "Tis(LAMN)",
+										"recurrence_n_category": "N2a",
+										"recurrence_m_category": "M1d(1)",
+										"recurrence_stage_group": "Stage IIIA",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					}
+				],
+				"comorbidities": [
+					{
+						"prior_malignancy": "No",
+						"laterality_of_prior_malignancy": "Bilateral",
+						"comorbidity_type_code": "C67.6",
+						"comorbidity_treatment_status": "Unknown",
+						"comorbidity_treatment": "Radiation therapy",
+						"age_at_comorbidity_diagnosis": 38
+					}
+				],
+				"exposures": [
+					{
+						"tobacco_smoking_status": "Current reformed smoker, duration not specified",
+						"tobacco_type": [
+							"Unknown",
+							"Electronic cigarettes",
+							"Not applicable"
+						],
+						"pack_years_smoked": 104.0
+					}
+				],
+				"biomarkers": [],
+				"followups": []
+			},
+			{
+				"submitter_donor_id": "DONOR_8",
+				"program_id": "SYNTHETIC-2",
+				"lost_to_followup_after_clinical_event_identifier": "",
+				"lost_to_followup_reason": "Discharged to palliative care",
+				"date_alive_after_lost_to_followup": "2022-03",
+				"is_deceased": false,
+				"cause_of_death": "Died of cancer",
+				"date_of_birth": "2003-12",
+				"date_of_death": null,
+				"gender": "Woman",
+				"sex_at_birth": "Unknown",
+				"primary_site": [
+					"Hypopharynx",
+					"Thymus",
+					"Esophagus",
+					"Colon"
+				],
+				"primary_diagnoses": [
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_14",
+						"date_of_diagnosis": "2019-07",
+						"cancer_type_code": "C02.1",
+						"basis_of_diagnosis": "Death certificate only",
+						"lymph_nodes_examined_status": "No lymph nodes found in resected specimen",
+						"lymph_nodes_examined_method": "Lymph node dissection/pathological exam",
+						"number_lymph_nodes_positive": 13,
+						"clinical_tumour_staging_system": "AJCC 6th edition",
+						"clinical_t_category": "T2(s)",
+						"clinical_n_category": "N1a",
+						"clinical_m_category": "M0",
+						"clinical_stage_group": "Regionalized",
+						"laterality": "Left",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_20",
+								"pathological_tumour_staging_system": "Durie-Salmon staging system",
+								"pathological_t_category": "T1b",
+								"pathological_n_category": "N0(mol+)",
+								"pathological_m_category": "M0(i+)",
+								"pathological_stage_group": "Stage IIIB",
+								"specimen_collection_date": "2021-02-23",
+								"specimen_storage": "RNA later frozen",
+								"tumour_histological_type": "8063/1",
+								"specimen_anatomic_location": "C15.9",
+								"reference_pathology_confirmed_diagnosis": "Not done",
+								"reference_pathology_confirmed_tumour_presence": "Not done",
+								"tumour_grading_system": "Grading system for GISTs",
+								"tumour_grade": "Grade IV",
+								"percent_tumour_cells_range": "0-19%",
+								"percent_tumour_cells_measurement_method": "Image analysis",
+								"specimen_processing": "Unknown",
+								"specimen_laterality": "Not applicable",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_26",
+										"specimen_tissue_source": "Bone marrow fluid",
+										"tumour_normal_designation": "Normal",
+										"specimen_type": "Recurrent tumour",
+										"sample_type": "Total DNA"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_20",
+								"is_primary_treatment": "Yes",
+								"treatment_start_date": "2021-02",
+								"treatment_end_date": "2022-09",
+								"treatment_setting": "Locally advanced",
+								"treatment_intent": "Diagnostic",
+								"days_per_cycle": 4,
+								"number_of_cycles": 5,
+								"line_of_treatment": 1,
+								"status_of_treatment": "Treatment stopped due to lack of efficacy (disease progression)",
+								"treatment_type": [
+									"Other targeting molecular therapy",
+									"Photodynamic therapy",
+									"Chemotherapy"
+								],
+								"response_to_treatment_criteria_method": "Physician Assessed Response Criteria",
+								"response_to_treatment": "Minor response",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [],
+								"surgery": {
+									"surgery_type": "Tumor Debulking",
+									"surgery_site": "C06",
+									"surgery_location": "Primary",
+									"tumour_focality": "Not applicable",
+									"residual_tumour_classification": "RX",
+									"margin_types_involved": [
+										"Unknown",
+										"Distal margin"
+									],
+									"margin_types_not_involved": [],
+									"margin_types_not_assessed": [],
+									"lymphovascular_invasion": "Venous (large vessel) invasion only",
+									"perineural_invasion": "Present",
+									"tumour_length": 3,
+									"tumour_width": 6,
+									"greatest_dimension_tumour": 5,
+									"submitter_specimen_id": null
+								},
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_26",
+										"date_of_followup": "2022-10",
+										"disease_status_at_followup": "Distant progression",
+										"relapse_type": "Local recurrence",
+										"date_of_relapse": "2022-10",
+										"method_of_progression_status": [
+											"Physical examination procedure (procedure)",
+											"Assessment of symptom control (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C06",
+										"recurrence_tumour_staging_system": "International Neuroblastoma Risk Group Staging System",
+										"recurrence_t_category": "T2(s)",
+										"recurrence_n_category": "N3c",
+										"recurrence_m_category": "M1c",
+										"recurrence_stage_group": "Stage IIIS",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					}
+				],
+				"comorbidities": [
+					{
+						"prior_malignancy": "Yes",
+						"laterality_of_prior_malignancy": "Unknown",
+						"comorbidity_type_code": "C64.9",
+						"comorbidity_treatment_status": "Yes",
+						"comorbidity_treatment": "Surgery",
+						"age_at_comorbidity_diagnosis": 51
+					}
+				],
+				"exposures": [
+					{
+						"tobacco_smoking_status": "Current reformed smoker for > 15 years",
+						"tobacco_type": [
+							"Waterpipe",
+							"Unknown"
+						],
+						"pack_years_smoked": 48.0
+					}
+				],
+				"biomarkers": [],
+				"followups": []
+			},
+			{
+				"submitter_donor_id": "DONOR_9",
+				"program_id": "SYNTHETIC-2",
+				"lost_to_followup_after_clinical_event_identifier": "",
+				"lost_to_followup_reason": "Withdrew from study",
+				"date_alive_after_lost_to_followup": "2022-05",
+				"is_deceased": false,
+				"cause_of_death": "Died of other reasons",
+				"date_of_birth": "1993-10",
+				"date_of_death": null,
+				"gender": "Woman",
+				"sex_at_birth": "Female",
+				"primary_site": [
+					"Trachea",
+					"Other and ill-defined digestive organs"
+				],
+				"primary_diagnoses": [
+					{
+						"submitter_primary_diagnosis_id": "PRIMARY_DIAGNOSIS_15",
+						"date_of_diagnosis": "2019-01",
+						"cancer_type_code": "C05.1",
+						"basis_of_diagnosis": "Specific tumour markers",
+						"lymph_nodes_examined_status": "Yes",
+						"lymph_nodes_examined_method": "Physical palpation of patient",
+						"number_lymph_nodes_positive": 15,
+						"clinical_tumour_staging_system": "International Neuroblastoma Staging System",
+						"clinical_t_category": "T3(s)",
+						"clinical_n_category": "N1b",
+						"clinical_m_category": "M1c(0)",
+						"clinical_stage_group": "Stage IIA",
+						"laterality": "Unilateral, side not specified",
+						"specimens": [
+							{
+								"submitter_specimen_id": "SPECIMEN_21",
+								"pathological_tumour_staging_system": "Durie-Salmon staging system",
+								"pathological_t_category": "Tis(DCIS)",
+								"pathological_n_category": "N2",
+								"pathological_m_category": "M1d(0)",
+								"pathological_stage_group": "Stage IIS",
+								"specimen_collection_date": "2020-12-07",
+								"specimen_storage": "Not Applicable",
+								"tumour_histological_type": "8630/9",
+								"specimen_anatomic_location": "C43.9",
+								"reference_pathology_confirmed_diagnosis": "Unknown",
+								"reference_pathology_confirmed_tumour_presence": "Not done",
+								"tumour_grading_system": "Four-tier grading system",
+								"tumour_grade": "High grade",
+								"percent_tumour_cells_range": "51-100%",
+								"percent_tumour_cells_measurement_method": "Unknown",
+								"specimen_processing": "Cryopreservation - other",
+								"specimen_laterality": "Left",
+								"sample_registrations": [
+									{
+										"submitter_sample_id": "SAMPLE_REGISTRATION_27",
+										"specimen_tissue_source": "Blood derived - peripheral blood",
+										"tumour_normal_designation": "Normal",
+										"specimen_type": "Normal",
+										"sample_type": "Protein"
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"treatments": [
+							{
+								"submitter_treatment_id": "TREATMENT_21",
+								"is_primary_treatment": "Unknown",
+								"treatment_start_date": "2021-03",
+								"treatment_end_date": "2022-10",
+								"treatment_setting": "Locally advanced",
+								"treatment_intent": "Forensic",
+								"days_per_cycle": 3,
+								"number_of_cycles": 3,
+								"line_of_treatment": 4,
+								"status_of_treatment": "Other",
+								"treatment_type": [
+									"Photodynamic therapy"
+								],
+								"response_to_treatment_criteria_method": "Response Assessment in Neuro-Oncology (RANO)",
+								"response_to_treatment": "Progressive disease",
+								"chemotherapies": [],
+								"hormone_therapies": [],
+								"immunotherapies": [],
+								"surgery": {
+									"surgery_type": "Pancreaticojejunostomy, side-to-side anastomosis",
+									"surgery_site": "C12",
+									"surgery_location": "Metastatic",
+									"tumour_focality": "Unknown",
+									"residual_tumour_classification": "R0",
+									"margin_types_involved": [],
+									"margin_types_not_involved": [
+										"Unknown"
+									],
+									"margin_types_not_assessed": [],
+									"lymphovascular_invasion": "Venous (large vessel) invasion only",
+									"perineural_invasion": "Present",
+									"tumour_length": 6,
+									"tumour_width": 6,
+									"greatest_dimension_tumour": 6,
+									"submitter_specimen_id": null
+								},
+								"followups": [
+									{
+										"submitter_follow_up_id": "FOLLOW_UP_27",
+										"date_of_followup": "2022-08",
+										"disease_status_at_followup": "Stable",
+										"relapse_type": "Distant recurrence/metastasis",
+										"date_of_relapse": "2022-06",
+										"method_of_progression_status": [
+											"Laboratory data interpretation (procedure)",
+											"Histopathology test (procedure)"
+										],
+										"anatomic_site_progression_or_recurrence": "C08",
+										"recurrence_tumour_staging_system": "International Neuroblastoma Staging System",
+										"recurrence_t_category": "T3b",
+										"recurrence_n_category": "N0(i-)",
+										"recurrence_m_category": "M1c(0)",
+										"recurrence_stage_group": "Stage 0",
+										"biomarkers": []
+									}
+								],
+								"biomarkers": []
+							}
+						],
+						"biomarkers": [],
+						"followups": []
+					}
+				],
+				"comorbidities": [],
+				"exposures": [],
+				"biomarkers": [],
+				"followups": []
+			}
+	]
+}


### PR DESCRIPTION
- Addresses DIG-1222, DIG-1253
- Adds an OpenAPI schema for Katsu ingest
- Changes Katsu ingest endpoint to /ingest/clinical_donors & uses connexion/openAPI schema for validation
- Implements endpoint for adding S3 credentials to vault
- Implements new htsget ingest model at /ingest/moh_variants/{program ID} endpoint

Testing:
* Try Katsu ingest endpoint (same instructions as before)
* Add an S3 credential to vault and ingest genomic data using the new request format (see README.md for instructions)