### PR TITLE
Add ETL validation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "clinical_ETL_code"]
+	path = clinical_ETL_code
+	url = https://github.com/CanDIG/clinical_ETL_code.git

--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ This repository can either be run standalone or as a Docker container.
 * Reference genome used for the variant files.
 * Manifest and mappings for clinical_ETL conversion.
 
-## Set environment variables
+## Setup
+Run the following:
+```bash
+pip install -r requirements.txt
+git submodule update --init --recursive
+```
+
+### Set environment variables
 
 * CANDIG_URL (same as TYK_LOGIN_TARGET_URL, if you're using CanDIGv2's example.env)
 * KEYCLOAK_PUBLIC_URL

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -87,6 +87,9 @@ partially ingested. You may need to delete the relevant programs in Katsu."}, 40
         return {"result": "Ingest encountered the following errors: %s" % error_string, "note": "Data may be partially \
 ingested. You may need to delete the relevant programs in Katsu. This was an internal error, so you may want to report \
 this issue to a CanDIG developer."}, 500
-    elif type(response) == IngestUserException:
-        return {"result": "Data error: %s" % response.value}, 400
+    elif isinstance(response, IngestUserException):
+        result = {"result": "Data error: %s" % response.value}
+        if type(response) == IngestValidationException:
+            result["validation_errors"] = response.validation_errors
+        return result, 400
     return "Unknown error", 500

--- a/ingest_result.py
+++ b/ingest_result.py
@@ -10,3 +10,8 @@ class IngestServerException(IngestResult):
 
 class IngestUserException(IngestResult):
     pass
+
+class IngestValidationException(IngestUserException):
+    def __init__(self, value, validation_errors):
+        super().__init__(value)
+        self.validation_errors = validation_errors

--- a/katsu_manifest.yml
+++ b/katsu_manifest.yml
@@ -1,0 +1,3 @@
+description: Katsu packet schema
+identifier: submitter_donor_id
+schema: https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ python-dotenv==0.14.0
 Flask==2.2.2
 connexion==2.14.1
 uwsgi==2.0.21
+dateparser~=1.1.0
+pandas~=1.3.4

--- a/single_ingest.json
+++ b/single_ingest.json
@@ -3,9 +3,6 @@
 			{
 				"submitter_donor_id": "DONOR_1",
 				"program_id": "SYNTHETIC-2",
-				"lost_to_followup_after_clinical_event_identifier": "",
-				"lost_to_followup_reason": "Not applicable",
-				"date_alive_after_lost_to_followup": "2022-02",
 				"is_deceased": true,
 				"cause_of_death": "Unknown",
 				"date_of_birth": "1961-07",
@@ -1139,7 +1136,6 @@
 					},
 					{
 						"prior_malignancy": "No",
-						"laterality_of_prior_malignancy": "Unilateral, Side not specified",
 						"comorbidity_type_code": "C02.1",
 						"comorbidity_treatment_status": "Yes",
 						"comorbidity_treatment": "Endoscopic therapy",
@@ -1157,22 +1153,10 @@
 						"pack_years_smoked": 280.0
 					},
 					{
-						"tobacco_smoking_status": "Not applicable",
-						"tobacco_type": [
-							"Chewing Tobacco",
-							"Pipe",
-							"Not applicable"
-						],
-						"pack_years_smoked": 138.0
+						"tobacco_smoking_status": "Not applicable"
 					},
 					{
-						"tobacco_smoking_status": "Not applicable",
-						"tobacco_type": [
-							"Cigar",
-							"Waterpipe",
-							"Electronic cigarettes"
-						],
-						"pack_years_smoked": 141.0
+						"tobacco_smoking_status": "Not applicable"
 					}
 				],
 				"biomarkers": [],
@@ -1181,7 +1165,6 @@
 			{
 				"submitter_donor_id": "DONOR_10",
 				"program_id": "SYNTHETIC-2",
-				"lost_to_followup_after_clinical_event_identifier": "",
 				"lost_to_followup_reason": "Not applicable",
 				"date_alive_after_lost_to_followup": "2022-03",
 				"is_deceased": true,
@@ -1320,8 +1303,8 @@
 			{
 				"submitter_donor_id": "DONOR_2",
 				"program_id": "SYNTHETIC-2",
-				"lost_to_followup_after_clinical_event_identifier": "",
 				"lost_to_followup_reason": "Discharged to palliative care",
+				"lost_to_followup_after_clinical_event_identifier": "",
 				"date_alive_after_lost_to_followup": "2022-10",
 				"is_deceased": false,
 				"cause_of_death": "Died of other reasons",
@@ -1654,6 +1637,7 @@
 							{
 								"submitter_specimen_id": "SPECIMEN_12",
 								"pathological_tumour_staging_system": "FIGO staging system",
+								"clinical_stage_group": "Stage IIS",
 								"pathological_t_category": "Tis pd",
 								"pathological_n_category": "N1b",
 								"pathological_m_category": "M0(i+)",
@@ -1742,7 +1726,6 @@
 				"comorbidities": [
 					{
 						"prior_malignancy": "Unknown",
-						"laterality_of_prior_malignancy": "Left",
 						"comorbidity_type_code": "C04.0",
 						"comorbidity_treatment_status": "Yes",
 						"comorbidity_treatment": "Other targeting molecular therapy",
@@ -1750,7 +1733,6 @@
 					},
 					{
 						"prior_malignancy": "No",
-						"laterality_of_prior_malignancy": "Midline",
 						"comorbidity_type_code": "C34.9",
 						"comorbidity_treatment_status": "Unknown",
 						"comorbidity_treatment": "Endoscopic therapy",
@@ -1789,8 +1771,8 @@
 			{
 				"submitter_donor_id": "DONOR_3",
 				"program_id": "SYNTHETIC-2",
-				"lost_to_followup_after_clinical_event_identifier": "",
 				"lost_to_followup_reason": "Discharged to palliative care",
+				"lost_to_followup_after_clinical_event_identifier": "",
 				"date_alive_after_lost_to_followup": "2022-01",
 				"is_deceased": true,
 				"cause_of_death": "Unknown",
@@ -2038,7 +2020,6 @@
 					},
 					{
 						"prior_malignancy": "No",
-						"laterality_of_prior_malignancy": "Left",
 						"comorbidity_type_code": "C43.9",
 						"comorbidity_treatment_status": "Unknown",
 						"comorbidity_treatment": "Endoscopic therapy",
@@ -2314,7 +2295,6 @@
 				"comorbidities": [
 					{
 						"prior_malignancy": "No",
-						"laterality_of_prior_malignancy": "Unknown",
 						"comorbidity_type_code": "C67.6",
 						"comorbidity_treatment_status": "Unknown",
 						"comorbidity_treatment": "Radiation therapy",
@@ -2322,7 +2302,6 @@
 					},
 					{
 						"prior_malignancy": "No",
-						"laterality_of_prior_malignancy": "Unknown",
 						"comorbidity_type_code": "C02.0",
 						"comorbidity_treatment_status": "No",
 						"comorbidity_treatment": "Photodynamic therapy",
@@ -2336,8 +2315,8 @@
 			{
 				"submitter_donor_id": "DONOR_5",
 				"program_id": "SYNTHETIC-2",
-				"lost_to_followup_after_clinical_event_identifier": "",
 				"lost_to_followup_reason": "Completed study",
+				"lost_to_followup_after_clinical_event_identifier": "",
 				"date_alive_after_lost_to_followup": "2022-02",
 				"is_deceased": true,
 				"cause_of_death": "Died of other reasons",
@@ -2458,7 +2437,6 @@
 				"comorbidities": [
 					{
 						"prior_malignancy": "Unknown",
-						"laterality_of_prior_malignancy": "Midline",
 						"comorbidity_type_code": "C03.9",
 						"comorbidity_treatment_status": "Yes",
 						"comorbidity_treatment": "Bone marrow transplant",
@@ -2605,7 +2583,6 @@
 				"comorbidities": [
 					{
 						"prior_malignancy": "No",
-						"laterality_of_prior_malignancy": "Left",
 						"comorbidity_type_code": "C02.1",
 						"comorbidity_treatment_status": "Unknown",
 						"comorbidity_treatment": "Ablation",
@@ -2746,7 +2723,6 @@
 				"comorbidities": [
 					{
 						"prior_malignancy": "No",
-						"laterality_of_prior_malignancy": "Bilateral",
 						"comorbidity_type_code": "C67.6",
 						"comorbidity_treatment_status": "Unknown",
 						"comorbidity_treatment": "Radiation therapy",


### PR DESCRIPTION
- Adds ETL validation to Katsu ingest
    - Works on both command-line and endpoint
    - Adds a validation_errors key, a list of strings representing validation errors, for the endpoint when validation fails
    - Adds ETL as a submodule

To test:
- Run `git submodule update --init --recursive`
- Run on command-line and endpoint with single_ingest.json and ensure no validation errors are given
- Introduce errors and see if jsonschema/moh validation is triggered