### PR TITLE
DIG-1280: Detailed error codes for clinical ingest

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,15 @@
 from connexion import FlaskApp
 from flask import url_for, redirect
-
-import katsu_ingest
-import htsget_ingest
+import os
 
 def root():
     return redirect(url_for('ingest_operations_get_service_info'))
 
 def create_app():
+    if not os.getenv("CANDIG_URL"):
+        print("ERROR: CANDIG_URL not found. CanDIG stack environment variables likely not set. Please do so before "
+              "running the service.")
+        exit()
     connexionApp = FlaskApp(__name__, specification_dir='./')
     connexionApp.add_api('ingest_openapi.yaml', pythonic_params=True, strict_validation=True)
     app = connexionApp.app

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -51,7 +51,15 @@ paths:
                   type: object
   /ingest/clinical_donors:
     post:
-      description: Add a list of donors with clinical data produced by the clinical ETL.
+      description: |
+        Add a list of donors with clinical data produced by the clinical ETL. \
+        Response codes: \
+        0: Success \
+        1: Unauthorized \
+        2: Validation error (response body will be list of errors) \
+        3: Cohort exists \
+        4: Internal CanDIG error (timeout, problem with Katsu, problem with htsget...) \
+        5: Authorization error (same as previous but specifically for auth - vault, keycloak...)
       operationId: ingest_operations.add_clinical_donors
       requestBody:
         $ref: "#/components/requestBodies/ClinicalDonorRequest"

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -61,7 +61,31 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: "#/components/schemas/IngestResponse"
+        422:
+          description: User error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestResponse"
+        401:
+          description: Authorization error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestResponse"
+        403:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestResponse"
+        500:
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestResponse"
 components:
   parameters:
     ProgramId:
@@ -211,3 +235,15 @@ components:
       type: string
       description: An Authorization BearerToken header
       pattern: Bearer .+
+    IngestResponse:
+      type: object
+      properties:
+        result:
+          type: string
+          example: "Ingested 10 Donors"
+        response_code:
+          type: integer
+          example: 0
+        response_code_readable:
+          type: string
+          example: "Success"

--- a/ingest_result.py
+++ b/ingest_result.py
@@ -15,3 +15,6 @@ class IngestValidationException(IngestUserException):
     def __init__(self, value, validation_errors):
         super().__init__(value)
         self.validation_errors = validation_errors
+
+class IngestCohortException(IngestUserException):
+    pass

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -388,6 +388,9 @@ def main():
     katsu_server_url = os.environ.get("CANDIG_URL")
     headers = auth.get_auth_header()
     data_location = os.environ.get("CLINICAL_DATA_LOCATION")
+    if not data_location:
+        print("ERROR: Data location is not assigned. Please set the environment variable CLINICAL_DATA_LOCATION.")
+        exit()
 
     env_str = "env.sh"
 

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -10,7 +10,7 @@ import requests
 import jsonschema
 
 import auth
-from ingest_result import (IngestPermissionsException, IngestServerException, IngestUserException,
+from ingest_result import (IngestPermissionsException, IngestServerException, IngestCohortException,
                            IngestResult, IngestValidationException)
 
 sys.path.append('clinical_ETL_code')
@@ -319,10 +319,7 @@ def ingest_donor_with_clinical(katsu_server_url, dataset, headers):
 
     ingested_datasets = []
     for donor in dataset:
-        try:
-            program_id = donor.pop("program_id")
-        except KeyError:
-            return IngestUserException("Program ID missing from a donor.")
+        program_id = donor.pop("program_id")
         if program_id not in ingested_datasets:
             update_headers(headers)
             if KATSU_TRAILING_SLASH:
@@ -336,7 +333,7 @@ def ingest_donor_with_clinical(katsu_server_url, dataset, headers):
             response = requests.Session().send(request.prepare())
             if response.status_code != HTTPStatus.CREATED:
                     if 'unique' in response.text:
-                        return IngestUserException(f"Program {program_id} has already been ingested into Katsu. "
+                        return IngestCohortException(f"Program {program_id} has already been ingested into Katsu. "
                                                    "Please delete and try again.")
                     else:
                         return IngestServerException([f"\nREQUEST STATUS CODE: {response.status_code}"
@@ -348,7 +345,7 @@ def ingest_donor_with_clinical(katsu_server_url, dataset, headers):
             traverse_clinical_field(fields, donor, "donors", parents, types, [])
         except Exception as e:
             print(traceback.format_exc())
-            return IngestUserException(str(e))
+            return IngestServerException(str(e))
     fields.pop("programs")
     errors = ingest_fields(fields, katsu_server_url, headers)
     if errors:


### PR DESCRIPTION
* Resolves [DIG-1280](https://candig.atlassian.net/browse/DIG-1280)
* Adds numerical error codes to the responses of clinical ingest (see ticket/OpenAPI swagger for descriptions)
    * Also adds human readable names for the codes to the response
* Changes some HTTP status codes (400 -> 422 since OpenAPI/connexion should effectively catch all 400s)

"Bonus": Adds a couple print statements for when environment variables are not set since this has been an issue for a while

[DIG-1280]: https://candig.atlassian.net/browse/DIG-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ