### PR TITLE
Remove Katsu Trailing Slash option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,8 @@ RUN pip install -r requirements.txt
 
 COPY . /ingest_app
 
-ARG katsu_trailing_slash=FALSE
-ENV KATSU_TRAILING_SLASH=${katsu_trailing_slash}
-
 RUN chmod +x ./run.sh
-ENTRYPOINT ./run.sh "$KATSU_TRAILING_SLASH"
+ENTRYPOINT ./run.sh
 EXPOSE 1235
 
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,6 @@ To run, ensure you have docker installed and CanDIGv2 running, then run the foll
 docker build . --build-arg venv_python=3.10 --build-arg alpine_version=3.14 -t ingest_app
 docker run -p 1236:1235 -e CANDIG_URL="$CANDIG_URL" -e KEYCLOAK_PUBLIC_URL="$KEYCLOAK_PUBLIC_URL" -e VAULT_URL="http://candig.docker.internal:8200" -e CANDIG_CLIENT_ID="$CANDIG_CLIENT_ID" -e CANDIG_CLIENT_SECRET="$CANDIG_CLIENT_SECRET" --name candig-ingest-dev --add-host candig.docker.internal:[YOUR LOCAL IP] ingest_app
 ```
-If your Katsu install uses trailing slashes at the end of endpoints (e.g. `/katsu/v2/ingest/programs/`), append `--build-arg katsu_trailing_slash=TRUE` to the `docker build` command above. This is stored in the environment variable KATSU_TRAILING_SLASH so if you are running locally just set that environment variable.
 
 Also, Note that VAULT_URL's host is often set as 0.0.0.0, which the container may not be able to access;
 if so, set it to candig.docker.internal:8200 (or whatever your vault port is).

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -5,7 +5,7 @@ import traceback
 
 import auth
 from ingest_result import *
-from katsu_ingest import ingest_donor_with_clinical, setTrailingSlash
+from katsu_ingest import ingest_donor_with_clinical
 from htsget_ingest import htsget_ingest
 import config
 
@@ -58,8 +58,6 @@ def add_moh_variant(program_id):
     return 500
 
 def add_clinical_donors():
-    if os.environ.get("KATSU_TRAILING_SLASH") == "TRUE":
-        setTrailingSlash(True)
     katsu_server_url = os.environ.get("CANDIG_URL")
     dataset = connexion.request.json["donors"]
     headers = {}

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -16,8 +16,6 @@ from ingest_result import (IngestPermissionsException, IngestServerException, In
 sys.path.append('clinical_ETL_code')
 from clinical_ETL_code import validate_coverage
 
-KATSU_TRAILING_SLASH = False
-
 def update_headers(headers):
     """
     For new auth model
@@ -28,10 +26,6 @@ def update_headers(headers):
     headers["Authorization"] = f"Bearer {bearer}"
     """
     pass
-
-def setTrailingSlash(trailing_slash):
-    global KATSU_TRAILING_SLASH
-    KATSU_TRAILING_SLASH = trailing_slash
     
 def read_json(file_path):
     """Read data from either a URL or a local file in JSON format.
@@ -85,10 +79,7 @@ def delete_data(katsu_server_url, data_location):
 
     # Delete datasets for each program ID
     for program_id in program_id_list:
-        if KATSU_TRAILING_SLASH:
-            delete_url = f"{katsu_server_url}/katsu/v2/authorized/programs/{program_id}/"
-        else:
-            delete_url = f"{katsu_server_url}/katsu/v2/authorized/programs/{program_id}"
+        delete_url = f"{katsu_server_url}/katsu/v2/authorized/programs/{program_id}/"
         print(f"Deleting dataset {program_id}...")
 
         try:
@@ -135,10 +126,7 @@ def ingest_data(katsu_server_url, data_location):
     )
     ingest_finished = False
     for api_name, file_name in file_mapping.items():
-        if KATSU_TRAILING_SLASH:
-            ingest_str = f"/katsu/v2/ingest/{api_name}/"
-        else:
-            ingest_str = f"/katsu/v2/ingest/{api_name}"
+        ingest_str = f"/katsu/v2/ingest/{api_name}/"
         ingest_url = katsu_server_url + ingest_str
 
         print(f"Loading {file_name}...")
@@ -176,10 +164,7 @@ def ingest_fields(fields, katsu_server_url, headers):
             name = name_mappings[type]
         else:
             name = type
-        if KATSU_TRAILING_SLASH:
-            ingest_str = f"/katsu/v2/ingest/{name}/"
-        else:
-            ingest_str = f"/katsu/v2/ingest/{name}"
+        ingest_str = f"/katsu/v2/ingest/{name}/"
         ingest_url = katsu_server_url + ingest_str
 
         update_headers(headers)
@@ -325,10 +310,7 @@ def ingest_donor_with_clinical(katsu_server_url, dataset, headers):
             return IngestUserException("Program ID missing from a donor.")
         if program_id not in ingested_datasets:
             update_headers(headers)
-            if KATSU_TRAILING_SLASH:
-                program_endpoint = "/katsu/v2/ingest/programs/"
-            else:
-                program_endpoint = "/katsu/v2/ingest/programs"
+            program_endpoint = "/katsu/v2/ingest/programs/"
             request = requests.Request('POST', katsu_server_url + program_endpoint, headers=headers,
                           data=json.dumps([{"program_id": program_id}]))
             if not auth.is_authed(request):
@@ -401,11 +383,7 @@ def main():
         choices=range(1, 4),
         help="Select an option: 1=Run check, 2=Ingest data, 3=Delete a dataset, 4=Ingest DonorWithClinicalData",
     )
-    parser.add_argument("--katsu_trailing_slash", dest="katsu_trailing_slash",
-                        help="Set if Katsu uses a trailing slash after its endpoints", action='store_true')
     args = parser.parse_args()
-    if args.katsu_trailing_slash:
-        setTrailingSlash(args.katsu_trailing_slash)
 
     if args.choice is not None:
         choice = args.choice

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,2 @@
 #!/usr/bin/env bash
-if [[ $0 == "TRUE" ]]; then
-    export KATSU_TRAILING_SLASH="TRUE"
-fi
 uwsgi /ingest_app/uwsgi.ini


### PR DESCRIPTION
- Removes the ability to specify whether Katsu uses a trailing slash at the end of the ingest endpoints since all versions now use the trailing slash

**To test:**

- Run app.py and ensure clinical ingest works
- Run katsu_ingest.py and ensure that also works