### PR TITLE
Hotfix: don't try to ingest program if not valid

### DIFF
--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -267,7 +267,10 @@ def prepare_clinical_data_for_ingest(ingest_json):
 def ingest_clinical_data(ingest_json, headers):
     schemas_to_ingest = prepare_clinical_data_for_ingest(ingest_json)
     headers["Content-Type"] = "application/json"
+    status_code = 200
     for program in schemas_to_ingest.values():
+        if "schemas" not in program:
+            continue
         schemas = program.pop("schemas")
         ingest_results, status_code = ingest_schemas(schemas, headers)
         print(ingest_results, status_code)


### PR DESCRIPTION
When an invalid input json is entered, we should actually skip it so we can finish and return the errors.