### PR TITLE
DIG-1219: import clinical_etl_code as a package instead of a submodule

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10"]
-
+    env:
+      CANDIG_URL: "http://localhost"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Github Actions Test
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "clinical_ETL_code"]
-	path = clinical_ETL_code
-	url = https://github.com/CanDIG/clinical_ETL_code.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,6 @@ ADD ./requirements.txt /ingest_app/requirements.txt
 ADD ./requirements-container.txt /ingest_app/requirements-container.txt
 RUN pip install -r requirements-container.txt
 
-ADD ./clinical_ETL_code/requirements.txt /ingest_app/clinical_ETL_code/requirements.txt
-RUN pip install -r clinical_ETL_code/requirements.txt
-
 COPY . /ingest_app
 
 RUN chmod +x ./run.sh

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -8,8 +8,7 @@ from ingest_result import IngestServerException, IngestUserException, IngestResu
 import requests
 import sys
 from urllib.parse import urlparse
-sys.path.append("clinical_ETL_code")
-from clinical_ETL_code.schema import openapi_to_jsonschema
+from clinical_etl.schema import openapi_to_jsonschema
 import jsonschema
 
 

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -10,8 +10,7 @@ import requests
 import auth
 from ingest_result import IngestPermissionsException
 
-sys.path.append("clinical_ETL_code")
-from clinical_ETL_code.mohschema import MoHSchema
+from clinical_etl.mohschema import MoHSchema
 
 CANDIG_URL = os.environ.get("CANDIG_URL")
 

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 Flask==2.2.5
 connexion[swagger-ui]==2.14.1
-uwsgi==2.0.22
+uwsgi==2.0.23
 werkzeug>=2.3.8 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,10 @@ requests-mock>=1.11.0
 urllib3==1.26.18
 minio==7.1.7
 jsoncomparison~=1.1.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@main
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v1.1.0
 awscli==1.29.5
 python-dotenv==0.14.0
 dateparser~=1.1.0
 pandas~=1.3.4
 numpy>=1.22.2 # not directly required, pinned by Snyk to avoid a vulnerability
+clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v1.2.0

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -7,7 +7,7 @@ import re
 import katsu_ingest
 import htsget_ingest
 
-CANDIG_URL = os.getenv("CANDIG_URL", "")
+CANDIG_URL = os.getenv("CANDIG_URL", "http://localhost")
 HTSGET_URL = CANDIG_URL + "/genomics"
 
 


### PR DESCRIPTION
Also tagged the clinical_etl and authx packages with numbered versions.

Pytest should still work, which is now automatically tested as a github action.