### PR TITLE
Switch hg37 to hg38 in the test data

### DIFF
--- a/tests/genomic_ingest.json
+++ b/tests/genomic_ingest.json
@@ -13,7 +13,7 @@
         "metadata": {
             "sequence_type": "wgs",
             "data_type": "variant",
-            "reference": "hg37"
+            "reference": "hg38"
         },
         "samples": [
             {
@@ -36,7 +36,7 @@
         "metadata": {
             "sequence_type": "wgs",
             "data_type": "variant",
-            "reference": "hg37"
+            "reference": "hg38"
         },
         "samples": [
             {


### PR DESCRIPTION
# Description
Linked in the [CanDIGv2 PR](https://github.com/CanDIG/CanDIGv2/pull/403), this switches from hg37 to hg38 in the test data so that the frontend can easily access it from integration tests.