### PR TITLE
DIG-1471: fix schema url

### DIFF
--- a/tests/clinical_ingest.json
+++ b/tests/clinical_ingest.json
@@ -1,5 +1,5 @@
 {
-    "openapi_url": "https://raw.githubusercontent.com/CanDIG/katsu/sonchau/date_intervals_part_1/chord_metadata_service/mohpackets/docs/schema.yml",
+    "openapi_url": "https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml",
     "donors": [
         {
             "submitter_donor_id": "DONOR_1",


### PR DESCRIPTION
Update the katsu schema url after changes were merged