### PR TITLE
DIG-1482: Fix multi-program statistics bug

### DIFF
--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -276,7 +276,7 @@ def prepare_clinical_data_for_ingest(ingest_json):
         by_program[program_id]["schemas"]["programs"] = [
             {
                 "program_id": program_id,
-                "metadata": schema.statistics
+                "metadata": schema.statistics.copy()
             }
         ]
     return by_program


### PR DESCRIPTION
When multiple programs are ingested, statistics were not being stored correctly due to a reference rather than a copy of the statistics being stored.

Works for me locally on latest develop stack.

To test:
* comment out the integration test clean up step
* run integration tests
* check that 
```
curl -X "GET" "http://candig.docker.internal:5080/katsu/v2/authorized/programs/" \
     -H 'Authorization: Bearer <user 2 token>' \
     -H 'Content-Type: application/json'
```
returns object with expected number of total objects for `SYNTHETIC-2`, e.g. 4 donors etc.
