### PR TITLE
DIG-1376: add specific PR_NAME to dispatch action

### DIFF
--- a/.github/workflows/dispatch-actions.yml
+++ b/.github/workflows/dispatch-actions.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
             - name: Check out repository code
               uses: actions/checkout@v3
+            - name: Get Submodule PR name
+              id: get_pr_name
+              run: |
+                PR_NAME=$(curl -s -X GET -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq -r '.title')
+                echo "::set-output name=PR_NAME::$PR_NAME"
             - name: Create PR in CanDIGv2
               id: make_pr
               uses: jman005/github-action-pr-expanded@v0


### PR DESCRIPTION
Adding the PR name from the submodule will help us with making more informative release notes. Thanks @CourtneyGosselin for figuring it out.