### PR TITLE
Improve automated PR titles and description

### DIFF
--- a/.github/workflows/dispatch-actions.yml
+++ b/.github/workflows/dispatch-actions.yml
@@ -13,6 +13,21 @@ jobs:
     steps:
             - name: Check out repository code
               uses: actions/checkout@v3
+            - uses: actions/github-script@v6
+              id: get_pr_data
+              with:
+                script: |
+                    return (
+                      await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                        commit_sha: context.sha,
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                      })
+                    ).data[0];
+            - name: Pull Request data
+              run: |
+                echo '${{ fromJson(steps.get_pr_data.outputs.result).number }}'
+                echo '${{ fromJson(steps.get_pr_data.outputs.result).title }}'
             - name: Create PR in CanDIGv2
               id: make_pr
               uses: jman005/github-action-pr-expanded@v0
@@ -21,8 +36,8 @@ jobs:
                   parent_repository: ${{ env.PARENT_REPOSITORY }}
                   checkout_branch: ${{ env.CHECKOUT_BRANCH}}
                   pr_against_branch: ${{ env.PR_AGAINST_BRANCH }}
-                  pr_title: 'Submodule update from merging: ${{ github.event.pull_request.title }}'
-                  pr_description: "PR triggered by update to develop branch on ${{ github.repository }}. Commit hash: `${{ github.sha }}`."
+                  pr_title: 'Submodule update from merging: ${{ fromJson(steps.get_pr_data.outputs.result).title }}'
+                  pr_description: "PR triggered by update to develop branch on ${{ github.repository }}. Commit hash: `${{ github.sha }}`. PR link: [#${{ fromJson(steps.get_pr_data.outputs.result).number }}](https://github.com/${{ github.repository }}/pull/${{ fromJson(steps.get_pr_data.outputs.result).number }})"
                   owner: ${{ env.OWNER }}
                   submodule_path: lib/candig-ingest/candigv2-ingest
                   label: Submodule update

--- a/.github/workflows/dispatch-actions.yml
+++ b/.github/workflows/dispatch-actions.yml
@@ -36,7 +36,7 @@ jobs:
                   parent_repository: ${{ env.PARENT_REPOSITORY }}
                   checkout_branch: ${{ env.CHECKOUT_BRANCH}}
                   pr_against_branch: ${{ env.PR_AGAINST_BRANCH }}
-                  pr_title: 'Submodule update from merging: ${{ fromJson(steps.get_pr_data.outputs.result).title }}'
+                  pr_title: '${{ github.repository }} update from merging: ${{ fromJson(steps.get_pr_data.outputs.result).title }}'
                   pr_description: "PR triggered by update to develop branch on ${{ github.repository }}. Commit hash: `${{ github.sha }}`. PR link: [#${{ fromJson(steps.get_pr_data.outputs.result).number }}](https://github.com/${{ github.repository }}/pull/${{ fromJson(steps.get_pr_data.outputs.result).number }})"
                   owner: ${{ env.OWNER }}
                   submodule_path: lib/candig-ingest/candigv2-ingest


### PR DESCRIPTION
Adding an intermediary step based on this post: https://github.com/orgs/community/discussions/27071#discussioncomment-7121591

worked on a forked repo so hoping it works here too!

* Incorporated the pr title of the merged pr into the autogenerated pr
* Attempted to add a link to the triggering pr on the submodule's repo