### PR TITLE
DIG-1376 :Update GH Action to improve PR title and description

### DIFF
--- a/.github/workflows/dispatch-actions.yml
+++ b/.github/workflows/dispatch-actions.yml
@@ -27,13 +27,13 @@ jobs:
                   ).data[0];
             - name: Create PR in CanDIGv2
               id: make_pr
-              uses: CanDIG/github-action-pr-expanded@v4-alpha
+              uses: CanDIG/github-action-pr-expanded@v4
               with:
                   github_token: ${{ secrets.SUBMODULE_PR }}
                   parent_repository: ${{ env.PARENT_REPOSITORY }}
                   checkout_branch: ${{ env.CHECKOUT_BRANCH}}
                   pr_against_branch: ${{ env.PR_AGAINST_BRANCH }}
-                  pr_title: '${{ github.repository }} update from merging: ${{ fromJson(steps.get_pr_data.outputs.result).title }}'
+                  pr_title: '${{ github.repository }} merging: ${{ fromJson(steps.get_pr_data.outputs.result).title }}'
                   pr_description: "PR triggered by update to develop branch on ${{ github.repository }}. Commit hash: `${{ github.sha }}`. PR link: [#${{ fromJson(steps.get_pr_data.outputs.result).number }}](https://github.com/${{ github.repository }}/pull/${{ fromJson(steps.get_pr_data.outputs.result).number }})"
                   owner: ${{ env.OWNER }}
                   submodule_path: lib/candig-ingest/candigv2-ingest


### PR DESCRIPTION
* Updated all actions to latest versions
* Removed labelling
* More descriptive PR title that includes the triggering PR's title
* More descriptive PR description that includes a link to the triggering PR
* Change to using the forked action at https://github.com/CanDIG/github-action-pr-expanded/tree/v4