### PR TITLE
DIG-1463: Verify genomic files on ingest

### DIFF
--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -187,6 +187,9 @@ def htsget_ingest(ingest_json, headers):
             continue
 
         # create the corresponding DRS objects
+        if "samples" not in sample or len(sample["samples"]) == 0:
+            result[sample["genomic_file_id"]]["errors"].append("No samples were specified for the genomic file mapping")
+            break
         response = link_genomic_data(headers, sample)
         for err in response["errors"]:
             if "403" in err["error"]:

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -198,14 +198,7 @@ def htsget_ingest(ingest_json, headers):
                 status_code = 403
                 break
 
-        # validate the access method
-        url = f"{HTSGET_URL}/htsget/v1/variants/data/{sample['genomic_file_id']}"
-        header_resp = requests.get(url, headers=headers, params={"class": "header"})
-        if header_resp.status_code != 200:
-            result[sample["genomic_file_id"]]["errors"] = header_resp.text
-        else:
-            result[sample["genomic_file_id"]] = response
-        # result[sample["genomic_file_id"]] = response
+        result[sample["genomic_file_id"]] = response
     return result, status_code
 
 

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -102,9 +102,18 @@ def link_genomic_data(headers, sample):
     else:
         result["genomic"] = response.json()
 
-    # flag the genomic_drs_object for indexing:
-    url = f"{HTSGET_URL}/htsget/v1/variants/{genomic_drs_obj['id']}/index"
-    response = requests.get(url, headers=headers)
+    # verify that the genomic file exists and is readable
+    verify_url = f"{HTSGET_URL}/htsget/v1/variants/{genomic_drs_obj['id']}/verify"
+
+    response = requests.get(verify_url, headers=headers)
+    if response.status_code != 200:
+        result["errors"].append({"error": f"could not verify sample: {response.text}"})
+    elif not response.json()['result']:
+        result["errors"].append({"error": f"could not verify sample: {response.json()['message']}"})
+    else:
+        # flag the genomic_drs_object for indexing:
+        url =f"{HTSGET_URL}/htsget/v1/variants/{genomic_drs_obj['id']}/index"
+        response = requests.get(url, headers=headers)
     return result
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests-mock>=1.11.0
 urllib3==1.26.18
 minio==7.1.7
 jsoncomparison~=1.1.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.1.1
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.1.2
 awscli==1.29.5
 python-dotenv==0.14.0
 dateparser~=1.2.0

--- a/tests/genomic_ingest.json
+++ b/tests/genomic_ingest.json
@@ -23,7 +23,7 @@
         ]
     },
     {
-        "program_id": "SYNTHETIC-2",
+        "program_id": "SYNTHETIC-1",
         "genomic_file_id": "multisample_1",
         "main": {
             "access_method": "file:////app/htsget_server/data/files/multisample_1.vcf.gz",

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -34,8 +34,9 @@ def test_htsget_ingest(requests_mock):
             matcher = re.compile(f"{HTSGET_URL}/ga4gh/drs/v1/objects/.+")
             requests_mock.post(f"{HTSGET_URL}/ga4gh/drs/v1/objects", json=callback, status_code=200)
             requests_mock.get(matcher, status_code=404)
-
             matcher = re.compile(f"{HTSGET_URL}/htsget/v1/variants/.+/index")
+            requests_mock.get(matcher, status_code=200)
+            matcher = re.compile(f"{HTSGET_URL}/htsget/v1/variants/.+/verify")
             requests_mock.get(matcher, status_code=200)
             response = htsget_ingest.link_genomic_data(headers, sample)
             print(json.dumps(response, indent=4))

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -26,6 +26,9 @@ def test_prepare_clinical_ingest():
 def callback(request, context):
     return request.json()
 
+def verify_callback(request, context):
+    return {"result": True}
+
 def test_htsget_ingest(requests_mock):
     headers = {"Authorization": f"Bearer test", "Content-Type": "application/json"}
     with open("tests/genomic_ingest.json", "r") as f:
@@ -37,7 +40,7 @@ def test_htsget_ingest(requests_mock):
             matcher = re.compile(f"{HTSGET_URL}/htsget/v1/variants/.+/index")
             requests_mock.get(matcher, status_code=200)
             matcher = re.compile(f"{HTSGET_URL}/htsget/v1/variants/.+/verify")
-            requests_mock.get(matcher, status_code=200)
+            requests_mock.get(matcher, json=verify_callback, status_code=200)
             response = htsget_ingest.link_genomic_data(headers, sample)
             print(json.dumps(response, indent=4))
             assert len(response["errors"]) == 0


### PR DESCRIPTION
When ingesting genomic files, verify that the linked files are there and that they have the correct samples in them. The test here is just a mock, but this will be tested further in test_integration.