### PR TITLE
DIG-1490: Correct and improve s3 url parsing in ingest

### DIFF
--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -154,19 +154,17 @@ def add_file_drs_object(genomic_drs_obj, file, type, headers):
 
 
 def get_access_method(url):
-    if url.startswith("s3"):
-        return {
-            "type": "s3",
-            "access_id": url.replace("s3://", "")
-        }
-    elif url.startswith("file"):
+    if url.startswith("file"):
         return {
             "type": "file",
             "access_url": {
                 "url": url
             }
         }
-    return None
+    return {
+        "type": "s3",
+        "access_id": url
+    }
 
 
 def htsget_ingest(ingest_json, headers):

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -38,11 +38,15 @@ def link_genomic_data(headers, sample):
         genomic_drs_obj["contents"] = []
 
     # add GenomicDataDrsObject to contents
-    add_file_drs_object(genomic_drs_obj, sample["main"], sample["metadata"]["data_type"], headers)
+    response = add_file_drs_object(genomic_drs_obj, sample["main"], sample["metadata"]["data_type"], headers)
+    if "error" in response:
+        result["errors"].append(response["error"])
 
     if "index" in sample:
         # add GenomicIndexDrsObject to contents
-        add_file_drs_object(genomic_drs_obj, sample["index"], "index", headers)
+        response = add_file_drs_object(genomic_drs_obj, sample["index"], "index", headers)
+        if "error" in response:
+            result["errors"].append(response["error"])
 
     result["sample"] = []
     for clin_sample in sample["samples"]:
@@ -130,6 +134,8 @@ def add_file_drs_object(genomic_drs_obj, file, type, headers):
     }
     access_method = get_access_method(file["access_method"])
     if access_method is not None:
+        if "message" in access_method:
+            return {"error": access_method["message"]}
         obj["access_methods"].append(access_method)
     contents_obj = {
         "name": file["name"],
@@ -161,10 +167,36 @@ def get_access_method(url):
                 "url": url
             }
         }
+    try:
+        result = parse_aws_url(url)
+    except Exception as e:
+        return {
+            "message": str(e)
+        }
     return {
         "type": "s3",
         "access_id": url
     }
+
+
+def parse_aws_url(url):
+    """
+    Parse a url into s3 components
+    """
+    s3_url_parse = re.match(r"((https*|s3):\/\/(.+?))\/(.+)", url)
+    if s3_url_parse is not None:
+        if s3_url_parse.group(2) == "s3":
+            raise Exception(f"Incorrect URL format {url}. S3 URLs should be in the form http(s)://endpoint-url/bucket-name/object. If your object is stored at AWS S3, you can find more information about endpoint URLs at https://docs.aws.amazon.com/general/latest/gr/rande.html")
+        endpoint = s3_url_parse.group(1)
+        bucket_parse = re.match(r"(.+?)\/(.+)", s3_url_parse.group(4))
+        if bucket_parse is not None:
+            return {
+                "endpoint": endpoint,
+                "bucket": bucket_parse.group(1),
+                "object": bucket_parse.group(2)
+            }
+        raise Exception(f"S3 URI {url} does not contain a bucket name")
+    raise Exception(f"URI {url} cannot be parsed as an S3-style URI")
 
 
 def htsget_ingest(ingest_json, headers):
@@ -192,7 +224,7 @@ def htsget_ingest(ingest_json, headers):
             break
         response = link_genomic_data(headers, sample)
         for err in response["errors"]:
-            if "403" in err["error"]:
+            if "403" in err:
                 status_code = 403
                 break
 

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -122,6 +122,7 @@ components:
               endpoint:
                 type: string
                 description: URL to the endpoint
+                pattern: (https*):\/\/(.+)
                 example: http://candig.docker.internal:9000
               bucket:
                 type: string

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -274,8 +274,9 @@ components:
       example: file:///data/samples/HG00096.vcf.gz
     S3Access:
       type: string
-      description: a description of an S3 URI
-      pattern: https*:\/\/(.+)\/(.+)\/(.+)
+      description: |
+        a description of an S3 URI. NB: even though the s3 prefix is incorrect, we allow it in parsing so that we can give better feedback to the user if a url is provided in that form.
+      pattern: (https*|s3):\/\/(.+)\/(.+)\/(.+)
       example: http://s3.us-east-1.amazonaws.com/1000genomes/HG00096.vcf.gz
     SampleLink:
       type: object

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -275,8 +275,8 @@ components:
     S3Access:
       type: string
       description: a description of an S3 URI
-      pattern: s3:\/\/(.+)\/(.+)\/(.+)
-      example: s3://s3.us-east-1.amazonaws.com/1000genomes/HG00096.vcf.gz
+      pattern: https*:\/\/(.+)\/(.+)\/(.+)
+      example: http://s3.us-east-1.amazonaws.com/1000genomes/HG00096.vcf.gz
     SampleLink:
       type: object
       description: Link between donor data (e.g. MoH Sample Registrations) and the samples in the genomic data resource

--- a/tests/genomic_ingest.json
+++ b/tests/genomic_ingest.json
@@ -3,11 +3,11 @@
         "program_id": "SYNTHETIC-2",
         "genomic_file_id": "HG00096.cnv.vcf",
         "main": {
-            "access_method": "s3://s3.us-east-1.amazonaws.com/1000genomes/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz?public=true",
+            "access_method": "http://s3.us-east-1.amazonaws.com/1000genomes/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz?public=true",
             "name": "HG00096.cnv.vcf.gz"
         },
         "index": {
-            "access_method": "s3://s3.us-east-1.amazonaws.com/1000genomes/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz.tbi?public=true",
+            "access_method": "http://s3.us-east-1.amazonaws.com/1000genomes/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz.tbi?public=true",
             "name": "HG00096.cnv.vcf.gz.tbi"
         },
         "metadata": {

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -30,21 +30,22 @@ def verify_callback(request, context):
     return {"result": True}
 
 def test_htsget_ingest(requests_mock):
+    matcher = re.compile(f"{HTSGET_URL}/ga4gh/drs/v1/objects/.+")
+    requests_mock.post(f"{HTSGET_URL}/ga4gh/drs/v1/objects", json=callback, status_code=200)
+    requests_mock.get(matcher, status_code=404)
+    matcher = re.compile(f"{HTSGET_URL}/htsget/v1/variants/.+/index")
+    requests_mock.get(matcher, status_code=200)
+    matcher = re.compile(f"{HTSGET_URL}/htsget/v1/variants/.+/verify")
+    requests_mock.get(matcher, json=verify_callback, status_code=200)
+    matcher = re.compile(f"{HTSGET_URL}/htsget/v1/reads/.+/index")
+    requests_mock.get(matcher, status_code=200)
+    matcher = re.compile(f"{HTSGET_URL}/htsget/v1/reads/.+/verify")
+    requests_mock.get(matcher, json=verify_callback, status_code=200)
+
     headers = {"Authorization": f"Bearer test", "Content-Type": "application/json"}
     with open("tests/genomic_ingest.json", "r") as f:
         data = json.load(f)
         for sample in data:
-            matcher = re.compile(f"{HTSGET_URL}/ga4gh/drs/v1/objects/.+")
-            requests_mock.post(f"{HTSGET_URL}/ga4gh/drs/v1/objects", json=callback, status_code=200)
-            requests_mock.get(matcher, status_code=404)
-            matcher = re.compile(f"{HTSGET_URL}/htsget/v1/variants/.+/index")
-            requests_mock.get(matcher, status_code=200)
-            matcher = re.compile(f"{HTSGET_URL}/htsget/v1/variants/.+/verify")
-            requests_mock.get(matcher, json=verify_callback, status_code=200)
-            matcher = re.compile(f"{HTSGET_URL}/htsget/v1/reads/.+/index")
-            requests_mock.get(matcher, status_code=200)
-            matcher = re.compile(f"{HTSGET_URL}/htsget/v1/reads/.+/verify")
-            requests_mock.get(matcher, json=verify_callback, status_code=200)
             response = htsget_ingest.link_genomic_data(headers, sample)
             print(json.dumps(response, indent=4))
             assert len(response["errors"]) == 0
@@ -53,3 +54,31 @@ def test_htsget_ingest(requests_mock):
             assert "sample" in response
             assert len(response["sample"]) == len(sample["samples"])
             assert len(response["sample"][0]["contents"]) == 1
+
+    # bad sample:
+    bad_s3_sample = {
+        "program_id": "SYNTHETIC-2",
+        "genomic_file_id": "bad_sample.cnv.vcf",
+        "main": {
+            "access_method": "s3://1000genomes/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz?public=true",
+            "name": "bad_sample.cnv.vcf.gz"
+        },
+        "index": {
+            "access_method": "s3://s3.us-east-1.amazonaws.com/1000genomes/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz.tbi?public=true",
+            "name": "bad_sample.cnv.vcf.gz.tbi"
+        },
+        "metadata": {
+            "sequence_type": "wgs",
+            "data_type": "variant",
+            "reference": "hg38"
+        },
+        "samples": [
+            {
+                "genomic_file_sample_id": "bad_sample",
+                "submitter_sample_id": "SAMPLE_REGISTRATION_1"
+            }
+        ]
+    }
+    response = htsget_ingest.link_genomic_data(headers, bad_s3_sample)
+    print(json.dumps(response, indent=4))
+    assert len(response["errors"]) == 2


### PR DESCRIPTION
S3 URLs must start with http(s). This catches anything with s3 as the prefix and tries to explain why that's wrong.