### PR TITLE
Add a mapping for the multisample_2 sample ingested during integration tests

### DIFF
--- a/tests/genomic_ingest.json
+++ b/tests/genomic_ingest.json
@@ -50,6 +50,33 @@
         ]
     },
     {
+        "program_id": "SYNTHETIC-2",
+        "genomic_file_id": "multisample_2",
+        "main": {
+            "access_method": "file:////app/htsget_server/data/files/multisample_2.vcf.gz",
+            "name": "multisample_2.vcf.gz"
+        },
+        "index": {
+            "access_method": "file:////app/htsget_server/data/files/multisample_2.vcf.gz.tbi",
+            "name": "multisample_2.vcf.gz.tbi"
+        },
+        "metadata": {
+            "sequence_type": "wgs",
+            "data_type": "variant",
+            "reference": "hg38"
+        },
+        "samples": [
+            {
+                "genomic_file_sample_id": "TUMOR",
+                "submitter_sample_id": "SAMPLE_REGISTRATION_1"
+            },
+			{
+				"genomic_file_sample_id": "NORMAL",
+				"submitter_sample_id": "SAMPLE_REGISTRATION_2"
+			}
+        ]
+    },
+    {
         "program_id": "SYNTHETIC-1",
         "genomic_file_id": "NA02102",
         "main": {

--- a/tests/genomic_ingest.json
+++ b/tests/genomic_ingest.json
@@ -43,10 +43,10 @@
                 "genomic_file_sample_id": "TUMOR",
                 "submitter_sample_id": "SAMPLE_REGISTRATION_4"
             },
-			{
-				"genomic_file_sample_id": "NORMAL",
-				"submitter_sample_id": "SPECIMEN_5"
-			}
+            {
+                "genomic_file_sample_id": "NORMAL",
+                "submitter_sample_id": "SPECIMEN_5"
+            }
         ]
     },
     {
@@ -70,10 +70,10 @@
                 "genomic_file_sample_id": "TUMOR",
                 "submitter_sample_id": "SAMPLE_REGISTRATION_1"
             },
-			{
-				"genomic_file_sample_id": "NORMAL",
-				"submitter_sample_id": "SAMPLE_REGISTRATION_2"
-			}
+            {
+                "genomic_file_sample_id": "NORMAL",
+                "submitter_sample_id": "SAMPLE_REGISTRATION_2"
+            }
         ]
     },
     {


### PR DESCRIPTION
[CanDIGv2 PR (Use this)](https://github.com/CanDIG/CanDIGv2/pull/479)

# Description
- This creates a mapping for multisample_2, which is used in the frontend runbook as an example of a test genomic file that can be queried

# To Test
- Best tested from the CanDIGv2 PR