### PR TITLE
DIG-1517: Create ProgramAuthorizationSchema and its endpoints

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -132,13 +132,30 @@ def is_authed(request: requests.Request):
     return False
 
 
-def get_opa_access():
-    response, status_code = authx.auth.get_service_store_secret("opa", key="access")
+def add_program_to_opa(program_dict, token):
+    # check to see if the user is allowed to add program authorizations:
+    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="ingest/program", program=program_dict['program_id']):
+        return "User not authorized to add program authorizations", 403
+
+    response, status_code = authx.auth.add_program_to_opa(program_dict)
     return response, status_code
 
 
-def set_opa_access(input):
-    response, status_code = authx.auth.set_service_store_secret("opa", key="access", value=json.dumps(input))
+def get_program_in_opa(program_id, token):
+    # check to see if the user is allowed to add program authorizations:
+    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="ingest/program", program=program_id):
+        return "User not authorized to add program authorizations", 403
+
+    response, status_code = authx.auth.get_program_in_opa(program_id)
+    return response, status_code
+
+
+def remove_program_from_opa(program_id, token):
+    # check to see if the user is allowed to add program authorizations:
+    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="ingest/program", program=program_id):
+        return "User not authorized to add program authorizations", 403
+
+    response, status_code = authx.auth.remove_program_from_opa(program_id)
     return response, status_code
 
 

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -149,9 +149,9 @@ components:
       content:
         'application/json':
           schema:
-            $ref: "#/components/schemas/ClinicalETLMap"
+            $ref: "#/components/schemas/ClinicalDonor"
   schemas:
-    ClinicalETLMap:
+    ClinicalDonor:
       type: object
       properties:
         openapi_url:

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -198,6 +198,18 @@ components:
             total_cases:
               type: integer
               description: how many cases are in this dataset
+    IngestResponse:
+      type: object
+      properties:
+        result:
+          type: string
+          example: "Ingested 10 Donors"
+        response_code:
+          type: integer
+          example: 0
+        response_code_readable:
+          type: string
+          example: "Success"
     GenomicSample:
       type: object
       properties:
@@ -294,15 +306,3 @@ components:
       required:
         - submitter_sample_id
         - genomic_file_sample_id
-    IngestResponse:
-      type: object
-      properties:
-        result:
-          type: string
-          example: "Ingested 10 Donors"
-        response_code:
-          type: integer
-          example: 0
-        response_code_readable:
-          type: string
-          example: "Success"

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -28,6 +28,46 @@ paths:
               application/json:
                 schema:
                   type: object
+  /program:
+    post:
+      description: Add authorization information for a new program
+      operationId: ingest_operations.add_program_authorization
+      requestBody:
+        $ref: '#/components/requestBodies/ProgramAuthorizationRequest'
+      responses:
+          200:
+            description: Success
+            content:
+              application/json:
+                schema:
+                  type: object
+  /program/{program_id}:
+    parameters:
+      - in: path
+        name: program_id
+        schema:
+          type: string
+        required: true
+    get:
+      description: Get authorization information for a program
+      operationId: ingest_operations.get_program_authorization
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+    delete:
+      description: Delete authorization information for a program
+      operationId: ingest_operations.remove_program_authorization
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
   /program/{program_id}/email/{email}:
     parameters:
       - in: path
@@ -150,6 +190,11 @@ components:
         'application/json':
           schema:
             $ref: "#/components/schemas/ClinicalDonor"
+    ProgramAuthorizationRequest:
+      content:
+        'application/json':
+          schema:
+            $ref: "#/components/schemas/ProgramAuthorization"
   schemas:
     ClinicalDonor:
       type: object
@@ -215,7 +260,7 @@ components:
       properties:
         program_id:
           type: string
-          description: Name of the cohort this sample belongs to. The user must be authorized to add data to this cohort.
+          description: Name of the program this sample belongs to. The user must be authorized to add data to this program.
         genomic_file_id:
           type: string
           description: A unique name for this genomic data resource
@@ -306,3 +351,27 @@ components:
       required:
         - submitter_sample_id
         - genomic_file_sample_id
+    ProgramAuthorization:
+      type: object
+      description: Describes who is allowed to access a program
+      properties:
+        program_id:
+          type: string
+          description: name of the program
+        program_curators:
+          type: array
+          description: list of users who are program curators for this program
+          items:
+            type: string
+        team_members:
+          type: array
+          description: list of users who are original researchers for this program
+          items:
+            type: string
+        creation_date:
+          type: string
+          description: date program was created, for embargo purposes. This may or may not be the date of ingest.
+      required:
+        - program_id
+        - program_curators
+        - team_members

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -112,3 +112,72 @@ def add_clinical_donors():
     headers["Content-Type"] = "application/json"
     response, status_code = ingest_clinical_data(dataset, headers)
     return response, status_code
+
+
+def add_program_authorization():
+    program = connexion.request.json
+    headers = {}
+    if "Authorization" not in request.headers:
+        return generateResponse("Bearer token required", ERROR_CODES["UNAUTHORIZED"])
+    try:
+        # New auth model
+        # refresh_token = request.headers["Authorization"].split("Bearer ")[1]
+        # token = auth.get_bearer_from_refresh(refresh_token)
+        if not request.headers["Authorization"].startswith("Bearer "):
+            return generateResponse("Invalid bearer token", ERROR_CODES["UNAUTHORIZED"])
+        token = request.headers["Authorization"].split("Bearer ")[1]
+        headers["Authorization"] = "Bearer %s" % token
+    except Exception as e:
+        if "Invalid bearer token" in str(e):
+            return generateResponse("Bearer token invalid or unauthorized", ERROR_CODES["UNAUTHORIZED"])
+        return generateResponse("Unknown error during authorization", ERROR_CODES["AUTHORIZATIONERR"])
+    headers["Content-Type"] = "application/json"
+
+    response, status_code = auth.add_program_to_opa(program, token)
+    return response, status_code
+
+
+@app.route('/program/<path:program_id>')
+def get_program_authorization(program_id):
+    headers = {}
+    if "Authorization" not in request.headers:
+        return generateResponse("Bearer token required", ERROR_CODES["UNAUTHORIZED"])
+    try:
+        # New auth model
+        # refresh_token = request.headers["Authorization"].split("Bearer ")[1]
+        # token = auth.get_bearer_from_refresh(refresh_token)
+        if not request.headers["Authorization"].startswith("Bearer "):
+            return generateResponse("Invalid bearer token", ERROR_CODES["UNAUTHORIZED"])
+        token = request.headers["Authorization"].split("Bearer ")[1]
+        headers["Authorization"] = "Bearer %s" % token
+    except Exception as e:
+        if "Invalid bearer token" in str(e):
+            return generateResponse("Bearer token invalid or unauthorized", ERROR_CODES["UNAUTHORIZED"])
+        return generateResponse("Unknown error during authorization", ERROR_CODES["AUTHORIZATIONERR"])
+    headers["Content-Type"] = "application/json"
+
+    response, status_code = auth.get_program_in_opa(program_id, token)
+    return response, status_code
+
+
+@app.route('/program/<path:program_id>')
+def remove_program_authorization(program_id):
+    headers = {}
+    if "Authorization" not in request.headers:
+        return generateResponse("Bearer token required", ERROR_CODES["UNAUTHORIZED"])
+    try:
+        # New auth model
+        # refresh_token = request.headers["Authorization"].split("Bearer ")[1]
+        # token = auth.get_bearer_from_refresh(refresh_token)
+        if not request.headers["Authorization"].startswith("Bearer "):
+            return generateResponse("Invalid bearer token", ERROR_CODES["UNAUTHORIZED"])
+        token = request.headers["Authorization"].split("Bearer ")[1]
+        headers["Authorization"] = "Bearer %s" % token
+    except Exception as e:
+        if "Invalid bearer token" in str(e):
+            return generateResponse("Bearer token invalid or unauthorized", ERROR_CODES["UNAUTHORIZED"])
+        return generateResponse("Unknown error during authorization", ERROR_CODES["AUTHORIZATIONERR"])
+    headers["Content-Type"] = "application/json"
+
+    response, status_code = auth.remove_program_from_opa(program_id, token)
+    return response, status_code

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests-mock>=1.11.0
 urllib3==1.26.18
 minio==7.1.7
 jsoncomparison~=1.1.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.1.2
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/opa-roles
 awscli==1.29.5
 python-dotenv==0.14.0
 dateparser~=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests-mock>=1.11.0
 urllib3==1.26.18
 minio==7.1.7
 jsoncomparison~=1.1.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/opa-roles
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.2.1
 awscli==1.29.5
 python-dotenv==0.14.0
 dateparser~=1.2.0


### PR DESCRIPTION
* Updated auth methods from get_opa_access/set_opa_access to add_program_to_opa/get_program_in_opa to use the new [opa design](https://github.com/CanDIG/candig-opa/pull/52).
* Updated the add_user_to_dataset/remove_user_from_dataset methods to use ProgramAuthorizations.
* Added the /programs endpoint to create a new ProgramAuthorization.
* Misc cleanup of names.

Testing will be done in integration testing.