### PR TITLE
DIG-1549: Use private urls if running within a container

### DIFF
--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -13,8 +13,8 @@ import jsonschema
 
 
 CANDIG_URL = os.getenv("CANDIG_URL", "")
-HTSGET_URL = CANDIG_URL + "/genomics"
-DRS_HOST_URL = "drs://" + HTSGET_URL.replace(f"{urlparse(CANDIG_URL).scheme}://","")
+HTSGET_URL = os.getenv("HTSGET_URL", f"{CANDIG_URL}/genomics")
+DRS_HOST_URL = "drs://" + CANDIG_URL.replace(f"{urlparse(CANDIG_URL).scheme}://","") + "/genomics"
 
 
 def link_genomic_data(headers, sample):

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -12,7 +12,7 @@ from ingest_result import IngestPermissionsException
 
 from clinical_etl.mohschema import MoHSchema
 
-CANDIG_URL = os.environ.get("CANDIG_URL")
+KATSU_URL = os.environ.get("KATSU_URL")
 
 def update_headers(headers):
     """
@@ -93,8 +93,7 @@ def ingest_schemas(fields, headers):
                 name = name_mappings[type]
             else:
                 name = type
-            ingest_str = f"/katsu/v2/ingest/{name}/"
-            ingest_url = CANDIG_URL + ingest_str
+            ingest_url = f"{KATSU_URL}/v2/ingest/{name}/"
 
             created_count = 0
             total_count = len(fields[type])
@@ -301,9 +300,11 @@ def ingest_clinical_data(ingest_json, headers):
 
 def main():
     # check if os.environ.get("CANDIG_URL") is set
-    if CANDIG_URL is None:
-        print("ERROR: $CANDIG_URL is not set. Did you forget to run 'source env.sh'?")
-        exit()
+    if KATSU_URL is None:
+        if os.getenv("CANDIG_URL") is None:
+            print("ERROR: $CANDIG_URL is not set. Did you forget to run 'source env.sh'?")
+            exit()
+        KATSU_URL = f"{os.getenv('CANDIG_URL')}/katsu"
     headers = auth.get_auth_header()
 
     parser = argparse.ArgumentParser(description="A script that ingests clinical data into Katsu")

--- a/opa_ingest.py
+++ b/opa_ingest.py
@@ -7,7 +7,6 @@ import auth
 import re
 
 
-OPA_URL = os.getenv("OPA_URL")
 
 
 def add_user_to_dataset(user, dataset, token):

--- a/opa_ingest.py
+++ b/opa_ingest.py
@@ -7,8 +7,7 @@ import auth
 import re
 
 
-CANDIG_URL = os.getenv("CANDIG_URL", "")
-OPA_URL = CANDIG_URL + "/policy"
+OPA_URL = os.getenv("OPA_URL")
 
 
 def add_user_to_dataset(user, dataset, token):
@@ -54,8 +53,8 @@ def main():
 
     args = parser.parse_args()
     token = auth.get_site_admin_token()
-    if os.environ.get("CANDIG_URL") is None:
-        raise Exception("CANDIG_URL environment variable is not set")
+    if os.environ.get("OPA_URL") is None:
+        raise Exception("OPA_URL environment variable is not set")
     if args.userfile is not None:
         with open(args.userfile) as f:
             lines = f.readlines()

--- a/s3_ingest.py
+++ b/s3_ingest.py
@@ -7,12 +7,9 @@ import auth
 from pathlib import Path
 
 
-CANDIG_URL = os.getenv("CANDIG_URL", "")
-
-
 def main():
     parser = argparse.ArgumentParser(description="Script to ingest files into an S3-compatible bucket.")
-    
+
     parser.add_argument("--sample", help="file name of sample", required=False)
     parser.add_argument("--samplefile", help="file with list of file names of samples", required=False)
     parser.add_argument("--endpoint", help="s3 endpoint")
@@ -33,9 +30,6 @@ def main():
         samples.append(args.sample)
     else:
         raise Exception("Either a sample name or a file of samples is required.")
-
-    if CANDIG_URL == "":
-        raise Exception("CANDIG_URL environment variable is not set.")
 
     if args.awsfile:
         # parse the awsfile:


### PR DESCRIPTION
Ingest should use the private versions of container URLs if possible: if these are set as env vars by docker-compose, it should use those; if they are either not available or set by some other mechanism, e.g. env.sh, that means we're not running inside a container and we should use the public versions of the urls.