### PR TITLE
DIG-1543: better separation of results and errors

### DIFF
--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -99,6 +99,8 @@ def link_genomic_data(headers, sample):
                     break
         if not_found:
             genomic_drs_obj["contents"].append(contents_obj)
+    if len(result["sample"]) == 0:
+            result.pop("sample")
 
     # finally, post the genomic_drs_object
     response = requests.post(url, json=genomic_drs_obj, headers=headers)
@@ -203,32 +205,39 @@ def htsget_ingest(ingest_json, headers):
     with open("ingest_openapi.yaml") as f:
         openapi_text = f.read()
         json_schema = openapi_to_jsonschema(openapi_text, "GenomicSample")
-    result = {}
+    result = {
+        "errors": {},
+        "results": {}
+    }
     status_code = 200
     for sample in ingest_json:
-        result[sample["genomic_file_id"]] = {}
+        result["errors"][sample["genomic_file_id"]] = []
         # validate the json
         if sample["genomic_file_id"] == sample["main"]["name"] or sample["genomic_file_id"] == sample["index"]["name"]:
-            result[sample["genomic_file_id"]] = {"errors": f"Sample {sample['genomic_file_id']} cannot have the same name as one of its files."}
+            result["errors"][sample["genomic_file_id"]].append(f"Sample {sample['genomic_file_id']} cannot have the same name as one of its files.")
         else:
             for error in jsonschema.Draft202012Validator(json_schema).iter_errors(sample):
-                if "errors" not in result[sample["genomic_file_id"]]:
-                    result[sample["genomic_file_id"]]["errors"] = []
-                result[sample["genomic_file_id"]]["errors"].append(f"{' > '.join(error.path)}: {error.message}")
-        if "errors" in result[sample["genomic_file_id"]]:
+                result["errors"][sample["genomic_file_id"]].append(f"{' > '.join(error.path)}: {error.message}")
+        if len(result["errors"][sample["genomic_file_id"]]) > 0:
             continue
 
         # create the corresponding DRS objects
         if "samples" not in sample or len(sample["samples"]) == 0:
-            result[sample["genomic_file_id"]]["errors"].append("No samples were specified for the genomic file mapping")
+            result["errors"][sample["genomic_file_id"]].append("No samples were specified for the genomic file mapping")
             break
         response = link_genomic_data(headers, sample)
         for err in response["errors"]:
+            result["errors"][sample["genomic_file_id"]].append(err)
             if "403" in err:
                 status_code = 403
                 break
-
-        result[sample["genomic_file_id"]] = response
+        if len(result["errors"][sample["genomic_file_id"]]) == 0:
+            result["errors"].pop(sample["genomic_file_id"])
+        response.pop("errors")
+        if len(response) > 0:
+            result["results"][sample["genomic_file_id"]] = response
+    if len(result["errors"]) == 0:
+        result.pop("errors")
     return result, status_code
 
 

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -236,8 +236,6 @@ def htsget_ingest(ingest_json, headers):
         response.pop("errors")
         if len(response) > 0:
             result["results"][sample["genomic_file_id"]] = response
-    if len(result["errors"]) == 0:
-        result.pop("errors")
     return result, status_code
 
 


### PR DESCRIPTION
I have reworked the formatting of the results: now the result has two properties, `results` and `errors`, where all of the error messages for samples with errors are grouped together.

```
{
    "errors": {
        "HG00096.cnv.vcf": [
            "error creating file drs object: 403 {\n  \"message\": \"User is not authorized to POST\"\n}\n"
        ],
        "multisample_2": [
            "error creating file drs object: 403 {\n  \"message\": \"User is not authorized to POST\"\n}\n"
        ]
    },
    "results": {
        "multisample_1": {
            "genomic": {
                ...
            },
            "sample": [
                ...
            ]
        }
    }
}
```
