### PR TITLE
Extend timeout for ingest to be 60s

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -8,4 +8,4 @@ uid = candig
 master = true
 processes = 4
 
-harakiri = 30
+harakiri = 60


### PR DESCRIPTION
This is a temporary measure while we roll out performance enhancements. This PR won't fix the issue with tokens expiring midway through the ingest.