### PR TITLE
DIG-1653: S3 credential storage

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -131,9 +131,16 @@ def parse_aws_credential(awsfile):
     return {"access": access, "secret": secret}
 
 
-def store_aws_credential(endpoint, bucket, access, secret, token=None):
-    return authx.auth.store_aws_credential(token=token, endpoint=endpoint, bucket=bucket,
-                                           access=access, secret=secret)
+#####
+# AWS credentials
+#####
+
+def store_aws_credential(endpoint, bucket, access, secret, token):
+    if not is_site_admin(token):
+        return {"error": "Only site admins can store aws credentials"}, 403
+    return authx.auth.store_aws_credential(endpoint=endpoint, bucket=bucket, access=access, secret=secret)
+
+
 
 #####
 # Site roles

--- a/auth.py
+++ b/auth.py
@@ -110,7 +110,7 @@ def get_minio_client(token, s3_endpoint, bucket, access_key=None, secret_key=Non
     return authx.auth.get_minio_client(token=token, s3_endpoint=s3_endpoint, bucket=bucket, access_key=access_key, secret_key=secret_key, region=region, secure=secure)
 
 
-def parse_aws_credential(awsfile):
+def parse_s3_credential(awsfile):
     # parse the awsfile:
     access = None
     secret = None
@@ -135,22 +135,22 @@ def parse_aws_credential(awsfile):
 # AWS credentials
 #####
 
-def store_aws_credential(endpoint, bucket, access, secret, token):
+def store_s3_credential(endpoint, bucket, access, secret, token):
     if not is_site_admin(token):
         return {"error": "Only site admins can store aws credentials"}, 403
-    return authx.auth.store_aws_credential(endpoint=endpoint, bucket=bucket, access=access, secret=secret)
+    return authx.auth.store_s3_credential(endpoint=endpoint, bucket=bucket, access=access, secret=secret)
 
 
-def get_aws_credential(endpoint, bucket, token):
+def get_s3_credential(endpoint, bucket, token):
     if not is_site_admin(token):
         return {"error": "Only site admins can view aws credentials"}, 403
-    return authx.auth.get_aws_credential(endpoint=endpoint, bucket=bucket)
+    return authx.auth.get_s3_credential(endpoint=endpoint, bucket=bucket)
 
 
-def remove_aws_credential(endpoint, bucket, token):
+def remove_s3_credential(endpoint, bucket, token):
     if not is_site_admin(token):
         return {"error": "Only site admins can remove aws credentials"}, 403
-    return authx.auth.remove_aws_credential(endpoint=endpoint, bucket=bucket)
+    return authx.auth.remove_s3_credential(endpoint=endpoint, bucket=bucket)
 
 
 #####

--- a/auth.py
+++ b/auth.py
@@ -141,6 +141,17 @@ def store_aws_credential(endpoint, bucket, access, secret, token):
     return authx.auth.store_aws_credential(endpoint=endpoint, bucket=bucket, access=access, secret=secret)
 
 
+def get_aws_credential(endpoint, bucket, token):
+    if not is_site_admin(token):
+        return {"error": "Only site admins can view aws credentials"}, 403
+    return authx.auth.get_aws_credential(endpoint=endpoint, bucket=bucket)
+
+
+def remove_aws_credential(endpoint, bucket, token):
+    if not is_site_admin(token):
+        return {"error": "Only site admins can remove aws credentials"}, 403
+    return authx.auth.remove_aws_credential(endpoint=endpoint, bucket=bucket)
+
 
 #####
 # Site roles

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -170,7 +170,7 @@ def get_access_method(url):
             }
         }
     try:
-        result = parse_aws_url(url)
+        result = parse_s3_url(url)
     except Exception as e:
         return {
             "message": str(e)
@@ -181,7 +181,7 @@ def get_access_method(url):
     }
 
 
-def parse_aws_url(url):
+def parse_s3_url(url):
     """
     Parse a url into s3 components
     """

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -28,6 +28,39 @@ paths:
               application/json:
                 schema:
                   type: object
+  /s3-credential/endpoint/{endpoint_id}/bucket/{bucket_id}:
+    parameters:
+      - in: path
+        name: endpoint_id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: bucket_id
+        schema:
+          type: string
+        required: true
+    get:
+      description: get credentials for an S3 bucket
+      operationId: ingest_operations.get_s3_credential
+      responses:
+          200:
+            description: Success
+            content:
+              application/json:
+                schema:
+                  type: object
+    delete:
+      description: delete credentials for an S3 bucket
+      operationId: ingest_operations.delete_s3_credential
+      responses:
+          200:
+            description: Success
+            content:
+              application/json:
+                schema:
+                  type: object
+
   /site-role/{role_type}:
     parameters:
       - in: path

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -157,6 +157,16 @@ paths:
               application/json:
                 schema:
                   type: object
+    get:
+      description: List programs authorized on server
+      operationId: ingest_operations.list_program_authorizations
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
   /program/{program_id}:
     parameters:
       - in: path

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -182,6 +182,13 @@ def add_clinical_donors():
 # Program authorizations
 ####
 
+def list_program_authorizations():
+    token = request.headers['Authorization'].split("Bearer ")[1]
+
+    response, status_code = auth.list_programs_in_opa(token)
+    return response, status_code
+
+
 def add_program_authorization():
     program = connexion.request.json
     token = request.headers['Authorization'].split("Bearer ")[1]

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -1,6 +1,7 @@
 import connexion
 from flask import request, Flask
 import os
+import re
 import traceback
 import urllib.parse
 
@@ -68,10 +69,29 @@ def get_service_info():
     }
 
 
+####
+# S3 credentials
+####
+
 def add_s3_credential():
     data = connexion.request.json
     token = request.headers['Authorization'].split("Bearer ")[1]
     return auth.store_aws_credential(data["endpoint"], data["bucket"], data["access_key"], data["secret_key"], token)
+
+
+@app.route('/s3-credential/endpoint/<path:endpoint_id>/bucket/<path:bucket_id>')
+def get_s3_credential(endpoint_id, bucket_id):
+    token = request.headers['Authorization'].split("Bearer ")[1]
+    endpoint_cleaned = re.sub(r"\W", "_", endpoint_id)
+    return auth.get_aws_credential(endpoint_cleaned, bucket_id, token)
+
+
+@app.route('/s3-credential/endpoint/<path:endpoint_id>/bucket/<path:bucket_id>')
+def delete_s3_credential(endpoint_id, bucket_id):
+    token = request.headers['Authorization'].split("Bearer ")[1]
+    endpoint_cleaned = re.sub(r"\W", "_", endpoint_id)
+    return auth.remove_aws_credential(endpoint_cleaned, bucket_id, token)
+
 
 ####
 # Site roles

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -76,21 +76,21 @@ def get_service_info():
 def add_s3_credential():
     data = connexion.request.json
     token = request.headers['Authorization'].split("Bearer ")[1]
-    return auth.store_aws_credential(data["endpoint"], data["bucket"], data["access_key"], data["secret_key"], token)
+    return auth.store_s3_credential(data["endpoint"], data["bucket"], data["access_key"], data["secret_key"], token)
 
 
 @app.route('/s3-credential/endpoint/<path:endpoint_id>/bucket/<path:bucket_id>')
 def get_s3_credential(endpoint_id, bucket_id):
     token = request.headers['Authorization'].split("Bearer ")[1]
     endpoint_cleaned = re.sub(r"\W", "_", endpoint_id)
-    return auth.get_aws_credential(endpoint_cleaned, bucket_id, token)
+    return auth.get_s3_credential(endpoint_cleaned, bucket_id, token)
 
 
 @app.route('/s3-credential/endpoint/<path:endpoint_id>/bucket/<path:bucket_id>')
 def delete_s3_credential(endpoint_id, bucket_id):
     token = request.headers['Authorization'].split("Bearer ")[1]
     endpoint_cleaned = re.sub(r"\W", "_", endpoint_id)
-    return auth.remove_aws_credential(endpoint_cleaned, bucket_id, token)
+    return auth.remove_s3_credential(endpoint_cleaned, bucket_id, token)
 
 
 ####

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests-mock>=1.11.0
 urllib3==1.26.18
 minio==7.1.7
 jsoncomparison~=1.1.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/s3-token
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.4.0
 awscli>=1.29.5
 python-dotenv==0.14.0
 dateparser~=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests-mock>=1.11.0
 urllib3==1.26.18
 minio==7.1.7
 jsoncomparison~=1.1.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.3.0
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/s3-token
 awscli>=1.29.5
 python-dotenv==0.14.0
 dateparser~=1.2.0

--- a/s3_ingest.py
+++ b/s3_ingest.py
@@ -33,7 +33,7 @@ def main():
 
     if args.awsfile:
         # parse the awsfile:
-        result = auth.parse_aws_credential(args.awsfile)
+        result = auth.parse_s3_credential(args.awsfile)
         access_key = result["access"]
         secret_key = result["secret"]
         if "error" in result:


### PR DESCRIPTION
Picks up the authx change to store/get aws credentials. Also adds some endpoints to get and delete existing aws/s3 credentials. Tested in test_aws_credentials in integration tests in https://github.com/CanDIG/CanDIGv2/pull/592