### PR TITLE
Remove branch checkout from generate_test_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tests/small_dataset_clinical_ingest.json
 tests/small_dataset_genomic_ingest.json
 tests/clinical_data_validation_results.json
 .DS_Store
+tests/SYNTH*

--- a/generate_test_data.py
+++ b/generate_test_data.py
@@ -89,6 +89,7 @@ def main(args):
                 "schema_class": "MoHSchemaV3",
                 "donors": [donor]}
     for program, content in programs.items():
+        print(f"Saving {program}.json to tests/")
         with open(f"{ingest_repo_dir}/tests/{program}.json", "w+") as f:
             json.dump(content, f)
 

--- a/generate_test_data.py
+++ b/generate_test_data.py
@@ -32,8 +32,6 @@ def main(args):
             sys.exit()
     print(f"Cloning mohccn-synthetic-data repo into {args.tmp}")
     synth_repo = Repo.clone_from("https://github.com/CanDIG/mohccn-synthetic-data.git", args.tmp)
-    # TODO: remove next line when changes are merged into develop
-    synth_repo.git.checkout('mshadbolt/factory-boy-synth-data')
 
     try:
         if args.prefix:
@@ -77,6 +75,7 @@ def main(args):
     print("Removing repo.")
     shutil.rmtree(args.tmp)
 
+    print("Splitting by program...")
     programs = {}
     with open(f'{ingest_repo_dir}/tests/small_dataset_clinical_ingest.json', "r") as f:
         full_json = json.load(f)


### PR DESCRIPTION
- Updates generate_test_data so that it doesn't check out redundant branch
- adds SYNTH* to gitignore since files are now split by program