### PR TITLE
DIG-1720: clinical ingest is asynchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ The preferred method for clinical data ingest is using the API.
 
 #### API
 
-The clinical ingest API runs at `$CANDIG_URL/ingest/clinical`. Simply send a request with an authorized bearer token and a JSON body with your `DonorWithClinicalData` object. See the swagger UI/[schema](ingest_openapi.yaml) for the response format.
+The clinical ingest API runs at `$CANDIG_URL/ingest/clinical`. Simply send a request with an authorized bearer token and a JSON body with your `DonorWithClinicalData` object. See the swagger UI/[schema](ingest_openapi.yaml) for the response format. The request will return a response with a queue ID. You can check the status of your ingest using that ID at `$CANDIG_URL/ingest/status/{queue_id}`.
 
 #### Command line
 
 This method is mainly used for development work but may also be used if the JSON body is too big to send easily via POST.
 
-To ingest via the commandline script, the location of your clinical data JSON, credentials of a user authorized to ingest (`site_admin` or `program_curator`) and the `client_id` and `client_secret` must be specified. 
+To ingest via the commandline script, the location of your clinical data JSON, credentials of a user authorized to ingest (`site_admin` or `program_curator`) and the `client_id` and `client_secret` must be specified.
 
 If you are in a testing environment and the default site administrator is still in place, this can be done by copying the `env.sh` file to the ingest container and executing it
 
@@ -205,7 +205,7 @@ Use the `$CANDIG_URL/ingest/genomic` endpoint with the proper Authorization head
 
 #### Command line
 
-Command line ingest is done by calling the `htsget_ingest.py` script directly and referring to the genomic json ingest file as the `--samplefile`. The genomic ingest file will need to be copied into the running candig-ingest container. Only site administrators or program curators are allowed to ingest. If you are in a testing environment and the default site administrator is still in place, you can export the site administrator credentials by copying the `env.sh` file to the ingest container and executing it. 
+Command line ingest is done by calling the `htsget_ingest.py` script directly and referring to the genomic json ingest file as the `--samplefile`. The genomic ingest file will need to be copied into the running candig-ingest container. Only site administrators or program curators are allowed to ingest. If you are in a testing environment and the default site administrator is still in place, you can export the site administrator credentials by copying the `env.sh` file to the ingest container and executing it.
 
 ```bash
 docker cp env.sh candigv2_candig-ingest_1:ingest_app
@@ -228,7 +228,7 @@ The script `opa_ingest.py` can be used only to add Team member authorizations to
 ### API
 Use the `/ingest/program/` [endpoint](https://github.com/CanDIG/candigv2-ingest/blob/4257929feca00be0d4384433793fcdf1b4e4137b/ingest_openapi.yaml#L114) to add, update, or delete authorization information for a program. Authorization headers for a site admin user must be provided. A POST request adds authorization, while a DELETE request revokes it.
 
-The following is an example of the payload you would need to `POST` to `/ingest/program/{program_id}` to add the following user roles to `TEST-PROGRAM-1`: 
+The following is an example of the payload you would need to `POST` to `/ingest/program/{program_id}` to add the following user roles to `TEST-PROGRAM-1`:
 - `user1@test.ca` as a Team member
 - `user2@test.ca` as a Program curator
 
@@ -291,7 +291,7 @@ The script `generate_test_data.py` can be used to generate a json files for inge
 
 To run:
 
-* Set up a virtual environment and install requirements (if you haven't already). If running inside the ingest docker container, this shouldn't be needed. 
+* Set up a virtual environment and install requirements (if you haven't already). If running inside the ingest docker container, this shouldn't be needed.
 ```commandline
 pip install -r requirements.txt
 ```
@@ -300,7 +300,7 @@ pip install -r requirements.txt
 Usage:
 ```commandline
 python generate_test_data.py -h
-usage: generate_test_data.py [-h] [--prefix PREFIX] --tmp 
+usage: generate_test_data.py [-h] [--prefix PREFIX] --tmp
 
 A script that copies and converts data from mohccn-synthetic-data for ingest into CanDIG platform.
 

--- a/auth.py
+++ b/auth.py
@@ -7,54 +7,6 @@ import requests
 import urllib.parse
 
 
-"""
-For new auth model
-def get_bearer_from_refresh(refresh_token):
-    '''
-    Transforms a refresh token into a usable bearer token through keycloak.
-    Args:
-        refresh_token: A Keycloak refresh token.
-    Returns: A keycloak bearer token.
-    '''
-    return authx.auth.get_access_token(keycloak_url=os.getenv('KEYCLOAK_PUBLIC_URL'),
-                                       client_id=os.getenv("CANDIG_CLIENT_ID"),
-                                       client_secret=os.getenv('CANDIG_CLIENT_SECRET'),
-                                       refresh_token=refresh_token)
-"""
-
-"""
-For new auth model
-def get_refresh_token(username=None, password=None, refresh_token=None):
-    '''
-    Returns a fresh Keycloak refresh token from either a username/password or existing refresh token.
-    Args:
-        username: If refresh token is not provided, a Keycloak username.
-        password: If refresh token is not provided, a Keycloak password.
-        refresh_token: If username/password are not provided, a Keycloak refresh token.
-
-    Returns: A new Keycloak refresh token.
-
-    '''
-    if refresh_token:
-        return authx.auth.get_refresh_token(
-            keycloak_url=os.getenv('KEYCLOAK_PUBLIC_URL'),
-            client_id=os.getenv('CANDIG_CLIENT_ID'),
-            client_secret=os.getenv('CANDIG_CLIENT_SECRET'),
-            refresh_token=refresh_token
-        )
-    if (username and password):
-        return authx.auth.get_refresh_token(
-            keycloak_url=os.getenv('KEYCLOAK_PUBLIC_URL'),
-            client_id=os.getenv('CANDIG_CLIENT_ID'),
-            client_secret=os.getenv('CANDIG_CLIENT_SECRET'),
-            username=os.getenv(username),
-            password=os.getenv(password)
-        )
-    else:
-        raise ValueError("Username and password or refresh token required")
-"""
-
-
 def is_default_site_admin_set():
     if os.getenv("DEFAULT_SITE_ADMIN_USER") is not None:
         result, status_code = authx.auth.get_service_store_secret("opa", key=f"site_roles")
@@ -78,27 +30,6 @@ def is_site_admin(token):
         return True
     return False
 
-
-def is_authed(request: requests.Request):
-    if 'Authorization' not in request.headers:
-        return False
-
-    """
-    New auth model
-    request_object = json.dumps({
-        "url": request.url,
-        "method": request.method,
-        "headers": request.headers,
-        "data": request.data
-    })
-    """
-    request.path = request.url # Compatibility with old auth model
-
-    # New auth model:
-    # if (authx.auth.is_permissible(request_object)): return True
-    if (authx.auth.is_site_admin(request)):
-        return True
-    return False
 
 #####
 # AWS stuff

--- a/config.py
+++ b/config.py
@@ -1,1 +1,5 @@
+import os
+
+
 VERSION = "3.0.0-alpha"
+DAEMON_PATH = os.getenv("DAEMON_PATH", "~/tmp")

--- a/daemon.py
+++ b/daemon.py
@@ -1,0 +1,69 @@
+from config import DAEMON_PATH
+import os
+from watchdog.observers import Observer
+import watchdog.events
+from candigv2_logging.logging import initialize, CanDIGLogger
+import json
+from katsu_ingest import ingest_schemas
+
+
+KATSU_URL = os.environ.get("KATSU_URL")
+
+
+logger = CanDIGLogger(__file__)
+
+initialize()
+
+
+def ingest_file(file_path):
+    json_data = None
+    results = {}
+    results_path = os.path.join(DAEMON_PATH, "results", os.path.basename(file_path))
+    with open(file_path) as f:
+        json_data = json.load(f)
+    if json_data is not None:
+        logger.info(f"Ingesting {file_path}")
+        schemas_to_ingest = list(json_data.keys())
+        for program_id in schemas_to_ingest:
+            program = json_data[program_id]
+            schemas = program.pop("schemas")
+            ingest_results, status_code = ingest_schemas(schemas)
+            results[program_id] = ingest_results
+        with open(results_path, "w") as f:
+            json.dump(results, f)
+        os.remove(file_path)
+        return results, status_code
+    return {"error": f"No such file {file_path}"}, 404
+
+
+class DaemonHandler(watchdog.events.FileSystemEventHandler):
+    def on_created(self, event):
+        ingest_file(event.src_path)
+
+
+if __name__ == "__main__":
+    ## look for any backlog IDs, ingest those, then listen for new IDs to ingest.
+    ingest_path = os.path.join(DAEMON_PATH, "to_ingest")
+    logger.info(f"ingesting started on {ingest_path}")
+    to_ingest = os.listdir(ingest_path)
+    logger.info(f"Finishing backlog: ingesting {to_ingest}")
+    while len(to_ingest) > 0:
+        try:
+            file_path = f"{ingest_path}/{to_ingest.pop()}"
+            ingest_file(file_path)
+        except Exception as e:
+            logger.warning(str(e))
+        to_ingest = os.listdir(ingest_path)
+
+    # now that the backlog is complete, listen for new files created:
+    logger.info(f"listening for new files at {ingest_path}")
+    event_handler = DaemonHandler()
+    observer = Observer()
+    observer.schedule(event_handler, ingest_path, recursive=False)
+    observer.start()
+    try:
+        while observer.is_alive():
+            observer.join(1)
+    finally:
+        observer.stop()
+        observer.join()

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -415,6 +415,23 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/IngestResponse"
+  /status/{queue_id}:
+    parameters:
+      - in: path
+        name: queue_id
+        schema:
+          type: string
+        required: true
+    get:
+      description: Return status of ingest operation
+      operationId: ingest_operations.get_ingest_status
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
 components:
   requestBodies:
     S3CredentialRequest:

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -7,7 +7,7 @@ import urllib.parse
 
 import auth
 from ingest_result import *
-from katsu_ingest import ingest_clinical_data
+from katsu_ingest import prep_check_clinical_data
 from htsget_ingest import htsget_ingest
 from opa_ingest import remove_user_from_dataset, add_user_to_dataset
 import config
@@ -179,7 +179,7 @@ def add_clinical_donors():
     batch_size = int(connexion.request.args.get("batch_size", 1000))
     headers = get_headers()
     token = request.headers['Authorization'].split("Bearer ")[1]
-    response, status_code = ingest_clinical_data(dataset, token, batch_size)
+    response, status_code = prep_check_clinical_data(dataset, token, batch_size)
     if status_code == 200:
         ingest_uuid = add_to_queue(response)
         response = {"queue_id": ingest_uuid}

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -14,18 +14,6 @@ KATSU_URL = os.environ.get("KATSU_URL")
 logger = CanDIGLogger(__file__)
 
 
-def update_headers(headers):
-    """
-    For new auth model
-    refresh_token = headers["refresh_token"]
-    bearer = auth.get_bearer_from_refresh(refresh_token)
-    new_refresh = auth.get_refresh_token(refresh_token=refresh_token)
-    headers["refresh_token"] = new_refresh
-    headers["Authorization"] = f"Bearer {bearer}"
-    """
-    pass
-
-
 def read_json(file_path):
     """Read data from either a URL or a local file in JSON format.
 

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -3,9 +3,8 @@ import json
 import os
 import traceback
 from http import HTTPStatus
-
 import requests
-from authx.auth import get_site_admin_token
+from authx.auth import get_site_admin_token, create_service_token, is_action_allowed_for_program
 from clinical_etl.mohschemav3 import MoHSchemaV3
 from candigv2_logging.logging import initialize, CanDIGLogger
 
@@ -53,8 +52,16 @@ def read_json(file_path):
             return None
 
 
-def ingest_schemas(fields, headers, batch_size):
+## This will be called by the daemon
+def ingest_schemas(fields, batch_size=1000):
     result = {"errors": [], "results": []}
+
+    # Use service token to authenticate this with katsu
+    headers = {
+        "X-Service-Token": create_service_token(),
+        "Content-Type": "application/json"
+    }
+
     for type in fields:
         if len(fields[type]) > 0:
             ingest_url = f"{KATSU_URL}/v3/ingest/{type}/"
@@ -168,10 +175,6 @@ def traverse_clinical_field(fields, field: dict, ctype, parents, types, ingested
         parents.append((ctype, data[id_key]))
     subfields = field.keys()
     for subfield in subfields:
-        if id_key:
-            logger.info(f"Loading {subfield} for {data[id_key]}...")
-        else:
-            logger.info(f"Loading {subfield}...")
         if type(field[subfield]) == list:
             for elem in field[subfield]:
                 traverse_clinical_field(
@@ -226,12 +229,10 @@ def prepare_clinical_data_for_ingest(ingest_json):
             continue
         logger.info("Validation success.")
 
-        logger.info("Beginning ingest")
         donors = by_program[program_id].pop("donors")
         fields = {type: [] for type in types}
         for donor in donors:
             parents = [("programs", program_id)]
-            logger.info(f"Loading donor {donor['submitter_donor_id']}...")
             try:
                 ingested_ids = {}
                 traverse_clinical_field(
@@ -247,20 +248,24 @@ def prepare_clinical_data_for_ingest(ingest_json):
     return by_program
 
 
-def ingest_clinical_data(ingest_json, headers, batch_size):
+def ingest_clinical_data(ingest_json, token, batch_size):
     schemas_to_ingest = prepare_clinical_data_for_ingest(ingest_json)
-    headers["Content-Type"] = "application/json"
-    status_code = 200
-    for program in schemas_to_ingest.values():
-        if "schemas" not in program:
-            continue
-        schemas = program.pop("schemas")
-        ingest_results, status_code = ingest_schemas(schemas, headers, batch_size)
-        if len(ingest_results["errors"]) > 0:
-            program["errors"].extend(ingest_results["errors"])
-        else:
-            program["results"] = ingest_results["results"]
-    return schemas_to_ingest, status_code
+    result = {}
+
+    for program_id in schemas_to_ingest.keys():
+        program = schemas_to_ingest[program_id]
+        result["errors"] = {program_id: []}
+        if len(program["errors"]) > 0:
+            result["errors"][program_id].extend(program["errors"])
+        if not is_action_allowed_for_program(token, method="POST", path="/v3/ingest/programs/", program=program_id):
+            result["errors"][program_id].extend({"unauthorized": "user is not allowed to ingest to program"})
+        if len(result["errors"][program_id]) == 0:
+            result["errors"].pop(program_id)
+
+    # if any of the programs had errors, return:
+    if len(result["errors"]) > 0:
+        return result, 400
+    return schemas_to_ingest, 200
 
 
 def main():
@@ -275,7 +280,6 @@ def main():
         KATSU_URL = f"{os.getenv('CANDIG_URL')}/katsu"
 
     token = get_site_admin_token()
-    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
     parser = argparse.ArgumentParser(
         description="A script that ingests clinical data into Katsu"
@@ -302,8 +306,16 @@ def main():
             "https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml"
         )
 
-    result, status_code = ingest_clinical_data(ingest_json, headers, batch_size)
-    print(json.dumps(result, indent=2))
+    results = {}
+    json_data, status_code = ingest_clinical_data(ingest_json, token, batch_size)
+    schemas_to_ingest = list(json_data.keys())
+    for program_id in schemas_to_ingest:
+        program = json_data[program_id]
+        schemas = program.pop("schemas")
+        ingest_results, status_code = ingest_schemas(schemas)
+        results[program_id] = ingest_results
+
+    print(json.dumps(results, indent=2))
 
 
 if __name__ == "__main__":

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -107,7 +107,7 @@ def ingest_schemas(fields, batch_size=1000):
 
 def traverse_clinical_field(fields, field: dict, ctype, parents, types, ingested_ids):
     """
-    Helper function for ingest_clinical_data. Parses and ingests clinical fields from a DonorWithClinicalData
+    Helper function for prep_check_clinical_data. Parses and ingests clinical fields from a DonorWithClinicalData
     object.
     Args:
         field: The (sub)field of a DonorWithClinicalData object, potentially nested
@@ -248,7 +248,7 @@ def prepare_clinical_data_for_ingest(ingest_json):
     return by_program
 
 
-def ingest_clinical_data(ingest_json, token, batch_size):
+def prep_check_clinical_data(ingest_json, token, batch_size):
     schemas_to_ingest = prepare_clinical_data_for_ingest(ingest_json)
     result = {}
 
@@ -307,7 +307,7 @@ def main():
         )
 
     results = {}
-    json_data, status_code = ingest_clinical_data(ingest_json, token, batch_size)
+    json_data, status_code = prep_check_clinical_data(ingest_json, token, batch_size)
     schemas_to_ingest = list(json_data.keys())
     for program_id in schemas_to_ingest:
         program = json_data[program_id]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ numpy>=1.22.2 # not directly required, pinned by Snyk to avoid a vulnerability
 clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.0.0
 GitPython>=3.1.42
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.0
+watchdog~=4.0.0

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,6 @@
 #!/usr/bin/env bash
+mkdir -p $DAEMON_PATH/to_ingest
+mkdir -p $DAEMON_PATH/results
+python /ingest_app/daemon.py &
+
 uwsgi /ingest_app/uwsgi.ini


### PR DESCRIPTION
Separates clinical ingest into parts:
- validation/authorization as a synchronous response to the API call
- validated/authed data stored in a temp file with a queue ID
- ingest executed by an asynchronous daemon process

User can get status of a queued ingest at the /status endpoint.

Tests are in https://github.com/CanDIG/CanDIGv2/pull/718