### PR TITLE
DIG-1407: ingest validates against running katsu

### DIFF
--- a/generate_test_data.py
+++ b/generate_test_data.py
@@ -85,7 +85,7 @@ def main(args):
             programs[donor['program_id']]['donors'].append(donor)
         except KeyError as e:
             programs[donor['program_id']] = {
-                "openapi_url": "https://raw.githubusercontent.com/CanDIG/katsu/model_3/chord_metadata_service/mohpackets/docs/schema.yml",
+                "openapi_url": "https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schemas/schema.yml",
                 "schema_class": "MoHSchemaV3",
                 "donors": [donor]}
     for program, content in programs.items():

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -59,6 +59,13 @@ def get_headers():
     return headers
 
 
+def check_default_site_admin(response):
+    if auth.is_default_site_admin_set():
+        if "warnings" not in response:
+            response["warnings"] = []
+        response["warnings"].append(f"Default site administrator {os.getenv('DEFAULT_SITE_ADMIN_USER')} is still configured. Use the /ingest/site-role/site_admin endpoint to set a different site admin.")
+
+
 # API endpoints
 def get_service_info():
     return {
@@ -175,8 +182,7 @@ def add_genomic_linkages():
     if status_code == 200:
         ingest_uuid = add_to_queue({"htsget": response, "do_not_index": do_not_index})
         response = {"queue_id": ingest_uuid}
-    if auth.is_default_site_admin_set():
-        response["warning"] = f"Default site administrator {os.getenv('DEFAULT_SITE_ADMIN_USER')} is still configured. Use the /ingest/site-role/site_admin endpoint to set a different site admin."
+    check_default_site_admin(response)
     return response, status_code
 
 
@@ -189,8 +195,7 @@ def add_clinical_donors():
     if status_code == 200:
         ingest_uuid = add_to_queue({"katsu": response})
         response = {"queue_id": ingest_uuid}
-    if auth.is_default_site_admin_set():
-        response["warning"] = f"Default site administrator {os.getenv('DEFAULT_SITE_ADMIN_USER')} is still configured. Use the /ingest/site-role/site_admin endpoint to set a different site admin."
+    check_default_site_admin(response)
     return response, status_code
 
 
@@ -233,8 +238,6 @@ def add_program_authorization():
     token = request.headers['Authorization'].split("Bearer ")[1]
 
     response, status_code = auth.add_program_to_opa(program, token)
-    if auth.is_default_site_admin_set():
-        response["warning"] = f"Default site administrator {os.getenv('DEFAULT_SITE_ADMIN_USER')} is still configured. Use the /ingest/site-role/site_admin endpoint to set a different site admin."
     return response, status_code
 
 

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -205,6 +205,15 @@ def prepare_clinical_data_for_ingest(ingest_json):
     (Fully outlined in MOH Schema)
     """
     schema = MoHSchemaV3(ingest_json["openapi_url"])
+
+    # check to see if we're running in an environment with an active katsu:
+    # if we can get a response for the katsu schema url, use that.
+    active_schema_url = f"{KATSU_URL}/static/schema.yml"
+    response = requests.get(active_schema_url)
+    if response.status_code == 200:
+        logger.info(f"Validating against active katsu schema at {active_schema_url}")
+        schema = MoHSchemaV3(active_schema_url)
+
     types = ["programs"]
     types.extend(schema.validation_schema.keys())
 

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -323,7 +323,7 @@ def main():
     ingest_json = read_json(data_location)
     if "openapi_url" not in ingest_json:
         ingest_json["openapi_url"] = (
-            "https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml"
+            "https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schemas/schema.yml"
         )
 
     results = {}

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -209,11 +209,13 @@ def prepare_clinical_data_for_ingest(ingest_json):
     # check to see if we're running in an environment with an active katsu:
     # if we can get a response for the katsu schema url, use that.
     active_schema_url = f"{KATSU_URL}/static/schema.yml"
-    response = requests.get(active_schema_url)
-    if response.status_code == 200:
-        logger.info(f"Validating against active katsu schema at {active_schema_url}")
-        schema = MoHSchemaV3(active_schema_url)
-
+    try:
+        response = requests.get(active_schema_url)
+        if response.status_code == 200:
+            logger.info(f"Validating against active katsu schema at {active_schema_url}")
+            schema = MoHSchemaV3(active_schema_url)
+    except:
+        pass
     types = ["programs"]
     types.extend(schema.validation_schema.keys())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ requests==2.32.2
 requests-mock>=1.11.0
 urllib3==1.26.18
 minio==7.1.7
-jsoncomparison~=1.1.0
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.4.5
 awscli>=1.29.5
 python-dotenv==0.14.0


### PR DESCRIPTION
Instead of necessarily validating against the schema listed in the clinical ingest json, try using the schema of the currently-running katsu instead. If these don't match, add a warning to the response so that the user knows why their validation is failing, if it's failing.

Make sure you're running the latest katsu: pull develop, build, compose.

Test this by trying to ingest a test clinical ingest file with an older schema specified, like 
```
 "openapi_url": "https://raw.githubusercontent.com/CanDIG/katsu/model_3/chord_metadata_service/mohpackets/docs/schema.yml"
```

You should get a warning in your response:
```
"CanDIG is using a different schema version than the one listed in the clinical data file! Please compare your data against fhttp://candig.docker.internal:5080/katsu/static/schema.yml."
```