### PR TITLE
hotfix: add back default warnings for site admin to endpoints

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -117,7 +117,7 @@ def set_role_type_in_opa(role_type, members, token):
 
 def add_program_to_opa(program_dict, token):
     # check to see if the user is allowed to add program authorizations:
-    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="ingest/program", program=program_dict['program_id']):
+    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/program", program=program_dict['program_id']):
         return {"error": f"User not authorized to add program authorizations for program {program_dict['program_id']}"}, 403
 
     response, status_code = authx.auth.add_program_to_opa(program_dict)
@@ -126,7 +126,7 @@ def add_program_to_opa(program_dict, token):
 
 def get_program_in_opa(program_id, token):
     # check to see if the user is allowed to add program authorizations:
-    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="ingest/program", program=program_id):
+    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/program", program=program_id):
         return {"error": "User not authorized to add program authorizations"}, 403
 
     response, status_code = authx.auth.get_program_in_opa(program_id)
@@ -142,7 +142,7 @@ def list_programs_in_opa(token):
 
 def remove_program_from_opa(program_id, token):
     # check to see if the user is allowed to add program authorizations:
-    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="ingest/program", program=program_id):
+    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/program", program=program_id):
         return {"error": "User not authorized to add program authorizations"}, 403
 
     response, status_code = authx.auth.remove_program_from_opa(program_id)

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -238,6 +238,7 @@ def add_program_authorization():
     token = request.headers['Authorization'].split("Bearer ")[1]
 
     response, status_code = auth.add_program_to_opa(program, token)
+    check_default_site_admin(response)
     return response, status_code
 
 
@@ -254,6 +255,7 @@ def remove_program_authorization(program_id):
     token = request.headers['Authorization'].split("Bearer ")[1]
 
     response, status_code = auth.remove_program_from_opa(program_id, token)
+    check_default_site_admin(response)
     return response, status_code
 
 


### PR DESCRIPTION
The only difference should be that it still works correctly and that the default site admin warnings come back for program endpoints.