### PR TITLE
Add an endpoint to echo back the user's refresh token.

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -32,8 +32,7 @@ def is_site_admin(token):
 
 
 def get_refresh_token(token):
-    with open("/run/secrets/client_secret", 'r') as f:
-        client_secret = f.read()
+    client_secret = authx.auth.get_service_store_secret(service="keycloak", key="client-secret")
     return authx.auth.get_oauth_response(
         client_secret = client_secret,
         refresh_token=token

--- a/auth.py
+++ b/auth.py
@@ -31,6 +31,14 @@ def is_site_admin(token):
     return False
 
 
+def get_refresh_token(token):
+    with open("/run/secrets/client_secret", 'r') as f:
+        client_secret = f.read()
+    return authx.auth.get_oauth_response(
+        client_secret = client_secret,
+        refresh_token=token
+        )
+
 #####
 # AWS stuff
 #####

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -439,6 +439,17 @@ paths:
             application/json:
               schema:
                 type: object
+  /get-token:
+    get:
+      description: Exchange the refresh token implicit in the request for a new one
+      operationId: ingest_operations.get_token
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
 components:
   requestBodies:
     S3CredentialRequest:

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -401,6 +401,8 @@ def remove_program_for_user(user_id, program_id):
 @app.route('/get-token')
 def get_token():
     # Attempt to grab the token via session_id
+    if not hasattr(request, 'cookies'):
+        return {'error': 'Unable to use the get-token endpoint without cookies'}, 200
     token = request.cookies['session_id']
 
     return {"token": token}, 200

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -403,11 +403,14 @@ def get_token():
     # Attempt to grab the token via session_id
     token = request.cookies['session_id']
 
-    # Exchange for a new token and return
-    try:
-        response = auth.get_refresh_token(token)
-        if "error" in response:
-            return {"error": response["error"]}, 500
-        return {"token": response["refresh_token"]}, 200
-    except Exception as e:
-        return {"error": str(e)}, 500
+    return {"token": token}, 200
+
+    # Uncomment the below to exchange for a new token and return
+    # that, instead
+    # try:
+    #    response = auth.get_refresh_token(token)
+    #    if "error" in response:
+    #        return {"error": response["error"]}, 500
+    #    return {"token": response["refresh_token"]}, 200
+    #except Exception as e:
+    #    return {"error": str(e)}, 500

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -397,3 +397,17 @@ def remove_program_for_user(user_id, program_id):
             response, status_code = auth.write_user_in_opa(response, token)
             return response, status_code
     return {"error": f"No program {program_id} found for user"}, status_code
+
+@app.route('/get-token')
+def get_token():
+    # Attempt to grab the token via session_id
+    token = request.cookies['session_id']
+
+    # Exchange for a new token and return
+    try:
+        response = auth.get_refresh_token(token)
+        if "error" in response:
+            return {"error": response["error"]}, 500
+        return {"token": response["refresh_token"]}, 200
+    except Exception as e:
+        return {"error": str(e)}, 500


### PR DESCRIPTION
# Ticket

- [DIG-1788](https://candig.atlassian.net/browse/DIG-1788)

# Description

This adds an endpoint that echoes back the user's refresh token. I've also written some now-unused code that would request a new refresh token for the user, but am unsure if we should go forwards with that, so I wrote this fallback.

[DIG-1788]: https://candig.atlassian.net/browse/DIG-1788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ