### PR TITLE
hotfix: check for multiple pages of clinical samples

### DIFF
--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -281,7 +281,11 @@ def check_genomic_data(dataset, token):
         samples_in_program = []
         response = requests.get(f"{KATSU_URL}/v3/authorized/sample_registrations", params={"program_id": program_id}, headers=headers)
         if response.status_code == 200:
-            samples_in_program = list(map(lambda x: x["submitter_sample_id"], response.json()["items"]))
+            if "next_page" in response.json():
+                count = response.json()["count"]
+                response = requests.get(f"{KATSU_URL}/v3/authorized/sample_registrations", params={"program_id": program_id, "page_size": count}, headers=headers)
+            if response.status_code == 200:
+                samples_in_program = list(map(lambda x: x["submitter_sample_id"], response.json()["items"]))
 
         for sample in by_program[program_id]:
             sample_errors = []

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -279,14 +279,9 @@ def check_genomic_data(dataset, token):
 
         # get all sample_registrations for this program
         samples_in_program = []
-        response = requests.get(f"{KATSU_URL}/v3/authorized/sample_registrations", params={"program_id": program_id}, headers=headers)
+        response = requests.get(f"{KATSU_URL}/v3/authorized/sample_registrations", params={"program_id": program_id, "page_size": 10000000}, headers=headers)
         if response.status_code == 200:
-            if "next_page" in response.json():
-                count = response.json()["count"]
-                response = requests.get(f"{KATSU_URL}/v3/authorized/sample_registrations", params={"program_id": program_id, "page_size": count}, headers=headers)
-            if response.status_code == 200:
-                samples_in_program = list(map(lambda x: x["submitter_sample_id"], response.json()["items"]))
-
+            samples_in_program.extend(list(map(lambda x: x["submitter_sample_id"], response.json()["items"])))
         for sample in by_program[program_id]:
             sample_errors = []
             # validate the json


### PR DESCRIPTION
In case there are more than 50 clinical samples in a program, we need to grab them all.