### PR TITLE
Hotfix: tweaks to htsget ingest, respawn daemon

### DIFF
--- a/daemon.sh
+++ b/daemon.sh
@@ -1,0 +1,4 @@
+until python daemon.py; do
+    echo "Daemon crashed with exit code $?.  Respawning.." >&2
+    sleep 1
+done

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 mkdir -p $DAEMON_PATH/to_ingest
 mkdir -p $DAEMON_PATH/results
-python /ingest_app/daemon.py &
+bash /ingest_app/daemon.sh &
 
 gunicorn server:app


### PR DESCRIPTION
Two things:
* added a wrapper so that if the daemon dies for any reason, it will respawn
* moved the indexing calls to the end of the htsget ingest

To test: recompose htsget with https://github.com/CanDIG/htsget_app/pull/327. Then ingest any genomic dataset. It should work much faster and not bother indexing until the end of the ingest.