### PR TITLE
DIG-1427: delete data as well as auth when deleting a program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,5 @@ env.sh
 _local
 .idea
 tmp/
-tests/small_dataset_clinical_ingest.json
-tests/small_dataset_genomic_ingest.json
-tests/clinical_data_validation_results.json
 .DS_Store
-tests/SYNTH*
+tests/

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -321,6 +321,13 @@ def check_genomic_data(dataset, token):
     return result, 400
 
 
+def delete_program(program_id, token):
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    url = f"{HTSGET_URL}/ga4gh/drs/v1/cohorts/{program_id}"
+
+    return requests.delete(url, headers=headers)
+
+
 def main():
     parser = argparse.ArgumentParser(description="A script that ingests genomic data into htsget.")
     parser.add_argument("--samplefile", required=True,

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -254,8 +254,9 @@ def htsget_ingest(ingest_json, do_not_index=False):
         }
 
     # send off index calls
-    for url in to_index:
-        response = requests.get(url, headers=headers, params={"do_not_index": do_not_index})
+    if not do_not_index:
+        for url in to_index:
+            response = requests.get(url, headers=headers, params={"do_not_index": do_not_index})
 
     return result, status_code
 

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -185,8 +185,8 @@ paths:
               schema:
                 type: object
     delete:
-      description: Delete authorization information for a program
-      operationId: ingest_operations.remove_program_authorization
+      description: Delete a program
+      operationId: ingest_operations.remove_program
       responses:
         200:
           description: Success

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -7,8 +7,8 @@ import urllib.parse
 
 import auth
 from ingest_result import *
-from katsu_ingest import prep_check_clinical_data
-from htsget_ingest import check_genomic_data
+import katsu_ingest
+import htsget_ingest
 from opa_ingest import remove_user_from_dataset, add_user_to_dataset
 import config
 import tempfile
@@ -179,7 +179,7 @@ def add_genomic_linkages():
     do_not_index = bool(connexion.request.args.get("do_not_index", False))
     headers = get_headers()
     token = request.headers['Authorization'].split("Bearer ")[1]
-    response, status_code = check_genomic_data(dataset, token)
+    response, status_code = htsget_ingest.check_genomic_data(dataset, token)
     if status_code == 200:
         ingest_uuid = add_to_queue({"htsget": response, "do_not_index": do_not_index})
         response = {"queue_id": ingest_uuid}
@@ -192,7 +192,7 @@ def add_clinical_donors():
     batch_size = int(connexion.request.args.get("batch_size", 1000))
     headers = get_headers()
     token = request.headers['Authorization'].split("Bearer ")[1]
-    response, status_code = prep_check_clinical_data(dataset, token, batch_size)
+    response, status_code = katsu_ingest.prep_check_clinical_data(dataset, token, batch_size)
     if status_code == 200:
         ingest_uuid = add_to_queue({"katsu": response})
         response = {"queue_id": ingest_uuid}
@@ -252,12 +252,34 @@ def get_program_authorization(program_id):
 
 
 @app.route('/program/<path:program_id>')
-def remove_program_authorization(program_id):
+def remove_program(program_id):
     token = request.headers['Authorization'].split("Bearer ")[1]
-
-    response, status_code = auth.remove_program_from_opa(program_id, token)
+    response = {"errors": {}}
     check_default_site_admin(response)
-    return response, status_code
+
+    opa_response, opa_status = auth.remove_program_from_opa(program_id, token)
+    katsu_response = katsu_ingest.delete_program(program_id, token)
+    htsget_response = htsget_ingest.delete_program(program_id, token)
+
+    if opa_status == 404:
+        # htsget status is not included here because it doesn't have a 404 response
+        return {"message": f"Program {program_id} not found"}, 404
+
+    if opa_status != 200:
+        response["errors"]["opa"] = {"message": opa_response, "status_code": opa_status}
+
+    if katsu_response.status_code != 204 and katsu_response.status_code != 404:
+        response["errors"]["katsu"] = {"message": katsu_response.text, "status_code": katsu_response.status_code}
+
+    if htsget_response.status_code != 200:
+        response["errors"]["htsget"] = {"message": htsget_response.text, "status_code": htsget_response.status_code}
+
+    if len(response["errors"]) == 0:
+        response.pop("errors")
+        response["message"] = f"Program {program_id} successfully deleted"
+        return response, 200
+
+    return response, 500
 
 
 @app.route('/program/<path:program_id>/email/<path:email>')

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -293,6 +293,13 @@ def prep_check_clinical_data(ingest_json, token, batch_size):
     return schemas_to_ingest, 200
 
 
+def delete_program(program_id, token):
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    url = f"{KATSU_URL}/v3/ingest/program/{program_id}/"
+
+    return requests.delete(url, headers=headers)
+
+
 def main():
     # check if os.environ.get("CANDIG_URL") is set
     global KATSU_URL


### PR DESCRIPTION
Delete the data in katsu and htsget when deleting a program, not just the program authorization. Also rolls in a fix for do_not_index: don't send the requests to index to htsget if the do_not_index flag is set.

This should pass integration tests in https://github.com/CanDIG/CanDIGv2/pull/848.