### PR TITLE
hotfix: List programs returns 500

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -143,7 +143,7 @@ def get_program_in_opa(program_id, token):
 def list_programs_in_opa(token):
     response, status_code = authx.auth.list_programs_in_opa()
     if status_code == 200:
-        return response
+        return response, 200
     return {"error": response}, status_code
 
 


### PR DESCRIPTION
I don't know how this was missed, but list_programs needs to return a status code as well as a response.

Test by running `curl "http://candig.docker.internal:5080/ingest/program"  -H 'Authorization: Bearer $TOKEN'`