### PR TITLE
hotfix: daemon should write out the error in the results

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -46,6 +46,7 @@ def ingest_file(file_path):
                         results[program_id] = ingest_results
                     except Exception as e:
                         results[program_id] = f"Exception: {type(e)} {str(e)}"
+        os.remove(file_path)
     except Exception as e:
         message = f"Couldn't load data from {file_path}: {type(e)} {str(e)}"
         logger.error(message)
@@ -53,7 +54,6 @@ def ingest_file(file_path):
         status_code = 500
     with open(results_path, "w") as f:
         json.dump(results, f)
-    os.remove(file_path)
     return results, status_code
 
 

--- a/daemon.py
+++ b/daemon.py
@@ -23,38 +23,38 @@ def ingest_file(file_path):
     try:
         with open(file_path) as f:
             json_data = json.load(f)
+        if json_data is not None:
+            logger.info(f"Ingesting {file_path}")
+            if "katsu" in json_data:
+                json_data = json_data["katsu"]
+                programs = list(json_data.keys())
+                for program_id in programs:
+                    try:
+                        ingest_results, status_code = ingest_schemas(json_data[program_id]["schemas"])
+                        results[program_id] = ingest_results
+                    except Exception as e:
+                        results[program_id] = f"Exception: {type(e)} {str(e)}"
+            elif "htsget" in json_data:
+                do_not_index = False
+                if "do_not_index" in json_data:
+                    do_not_index = json_data["do_not_index"]
+                json_data = json_data["htsget"]
+                programs = list(json_data.keys())
+                for program_id in programs:
+                    try:
+                        ingest_results, status_code = htsget_ingest(json_data[program_id], do_not_index)
+                        results[program_id] = ingest_results
+                    except Exception as e:
+                        results[program_id] = f"Exception: {type(e)} {str(e)}"
     except Exception as e:
         message = f"Couldn't load data from {file_path}: {type(e)} {str(e)}"
         logger.error(message)
         results["error"] = message
-    if json_data is not None:
-        logger.info(f"Ingesting {file_path}")
-        if "katsu" in json_data:
-            json_data = json_data["katsu"]
-            programs = list(json_data.keys())
-            for program_id in programs:
-                try:
-                    ingest_results, status_code = ingest_schemas(json_data[program_id]["schemas"])
-                    results[program_id] = ingest_results
-                except Exception as e:
-                    results[program_id] = f"Exception: {type(e)} {str(e)}"
-        elif "htsget" in json_data:
-            do_not_index = False
-            if "do_not_index" in json_data:
-                do_not_index = json_data["do_not_index"]
-            json_data = json_data["htsget"]
-            programs = list(json_data.keys())
-            for program_id in programs:
-                try:
-                    ingest_results, status_code = htsget_ingest(json_data[program_id], do_not_index)
-                    results[program_id] = ingest_results
-                except Exception as e:
-                    results[program_id] = f"Exception: {type(e)} {str(e)}"
-        with open(results_path, "w") as f:
-            json.dump(results, f)
-        os.remove(file_path)
-        return results, status_code
-    return {"error": f"No such file {file_path}"}, 404
+        status_code = 500
+    with open(results_path, "w") as f:
+        json.dump(results, f)
+    os.remove(file_path)
+    return results, status_code
 
 
 class DaemonHandler(watchdog.events.FileSystemEventHandler):


### PR DESCRIPTION
If there is a fluke error in the daemon (sometimes it seems like the temp file doesn't get written correctly or something?), we should write that error out in the results so that the ingest status is known.