### PR TITLE
Clean up requirements

### DIFF
--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -7,3 +7,4 @@ connexion[flask]
 gunicorn>=23.0.0
 uvicorn[standard]==0.30.6
 werkzeug>=2.3.8 # not directly required, pinned by Snyk to avoid a vulnerability
+watchdog~=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests==2.32.2
+requests-mock>=1.12.1
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.1
 clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.1.0
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,4 @@
-PyYAML==6.0.1
 requests==2.32.2
-requests-mock>=1.12.1
-minio==7.2.12
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.1
-awscli>=1.29.5
-python-dotenv==0.14.0
-dateparser~=1.2.0
-pandas~=2.1.4
-numpy>=1.22.2 # not directly required, pinned by Snyk to avoid a vulnerability
 clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.1.0
-GitPython>=3.1.42
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
-watchdog~=4.0.0


### PR DESCRIPTION
I was reconsidering the requirements in this repo and realized that a lot of these are actually from back when we pulled clinical_etl separately into this repo instead of importing it as a module. It's probably safest to let the clinical_etl module version dictate those requirements instead of explicitly listing them here.

I also moved watchdog to requirements_container, since it's only needed in the container context.