### PR TITLE
Add an endpoint for userse to see their own authorization status

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -193,6 +193,16 @@ def list_pending_users_in_opa(token):
     return response, status_code
 
 
+def is_self_pending(token):
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"pending_users")
+    if status_code == 200:
+        user_name = get_user_name(token)
+        response = user_name in response["pending_users"]
+    else:
+        response = False
+    return response, status_code
+
+
 def approve_pending_user_in_opa(user_name, token):
     if not is_site_admin(token):
         return {"error": f"User not authorized to approve pending users"}, 403
@@ -254,6 +264,12 @@ def get_user_in_opa(user_name, token):
         return {"error": f"User not authorized to view users"}, 403
 
     safe_name = urllib.parse.quote_plus(user_name)
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"users/{safe_name}")
+    return response, status_code
+
+
+def get_self_in_opa(token):
+    safe_name = urllib.parse.quote_plus(get_user_name(token))
     response, status_code = authx.auth.get_service_store_secret("opa", key=f"users/{safe_name}")
     return response, status_code
 

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -317,6 +317,18 @@ paths:
             application/json:
               schema:
                 type: object
+  /user/self_authorize:
+    get:
+      summary: List program authorizations
+      description: List authorizations for programs for the authenticated user
+      operationId: ingest_operations.is_self_authorized
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
   /user/{user_id}/authorize:
     parameters:
       - in: path

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -317,11 +317,11 @@ paths:
             application/json:
               schema:
                 type: object
-  /user/self_authorize:
+  /user/self/authorize:
     get:
-      summary: List program authorizations
+      summary: List own program authorizations
       description: List authorizations for programs for the authenticated user
-      operationId: ingest_operations.is_self_authorized
+      operationId: ingest_operations.list_programs_for_self
       responses:
         200:
           description: Success

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -317,18 +317,6 @@ paths:
             application/json:
               schema:
                 type: object
-  /user/self/authorize:
-    get:
-      summary: List own program authorizations
-      description: List authorizations for programs for the authenticated user
-      operationId: ingest_operations.list_programs_for_self
-      responses:
-        200:
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: object
   /user/{user_id}/authorize:
     parameters:
       - in: path
@@ -336,6 +324,7 @@ paths:
         schema:
           type: string
         required: true
+        description: The user ID to check. If "me", return information about the requesting user
     get:
       summary: List program authorizations
       description: List authorizations for programs for a user

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -362,7 +362,8 @@ def clear_pending_users():
 # DAC authorization for users
 ####
 
-def is_self_authorized():
+@app.route('/user/self/authorize')
+def list_programs_for_self():
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
     response, status_code = auth.get_self_in_opa(token)
     if status_code == 404:

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -362,6 +362,19 @@ def clear_pending_users():
 # DAC authorization for users
 ####
 
+def is_self_authorized():
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+    response, status_code = auth.get_self_in_opa(token)
+    if status_code == 404:
+        # We next check if the user is pending
+        response, status_code = auth.is_self_pending(token)
+        # NB: The results is a string if unauthorized or pending, and a list otherwise
+        return {"results": "Pending" if response else "Unauthorized"}, status_code
+    print(response)
+    # NB: The results is a list if authorized, and a string otherwise
+    return {"results": list(response["programs"].values())}, status_code
+
+
 @app.route('/user/<path:user_id>/authorize')
 def list_programs_for_user(user_id):
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -362,29 +362,34 @@ def clear_pending_users():
 # DAC authorization for users
 ####
 
-@app.route('/user/self/authorize')
-def list_programs_for_self():
-    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+def list_programs_for_self(token):
     response, status_code = auth.get_self_in_opa(token)
     if status_code == 404:
         # We next check if the user is pending
         response, status_code = auth.is_self_pending(token)
         # NB: The results is a string if unauthorized or pending, and a list otherwise
-        return {"results": "Pending" if response else "Unauthorized"}, status_code
+        return "Pending" if response else "Unauthorized", status_code
     print(response)
     # NB: The results is a list if authorized, and a string otherwise
-    return {"results": list(response["programs"].values())}, status_code
+    return list(response["programs"].values()), status_code
 
 
 @app.route('/user/<path:user_id>/authorize')
 def list_programs_for_user(user_id):
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
-    user_name = urllib.parse.unquote_plus(user_id)
-    response, status_code = auth.get_user_in_opa(user_name, token)
-    if status_code != 200:
-        return response, status_code
+    response = ""
+    status_code = 0
+    if user_id == "me":
+        # Grab the user's own authorization
+        response, status_code = list_programs_for_self(token)
+    else:
+        user_name = urllib.parse.unquote_plus(user_id)
+        response, status_code = auth.get_user_in_opa(user_name, token)
+        if status_code != 200:
+            return response, status_code
+        response = list(response["programs"].values())
     print(response)
-    return {"results": list(response["programs"].values())}, status_code
+    return {"results": response}, status_code
 
 
 @app.route('/user/<path:user_id>/authorize')


### PR DESCRIPTION
# Jira Ticket
[DIG-1857](https://candig.atlassian.net/browse/DIG-1857)

# Description
This adds an endpoint (`/user/self_authorize`) to allow a user to see their own authorization status.

# To Test
- Delete the site admin from the authorized users list like so:
```
(candig) 16:13 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ docker exec -it candigv2_candig-ingest_1 python
Python 3.12.8 (main, Dec  4 2024, 20:39:47) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import authx.auth
>>> authx.auth.delete_service_store_secret("opa", key=f"users/site_admin@test.ca")
204
```
- Check that you are unauthorized via the ingest API like so:
```
(candig) 13:18 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ curl candig.docker.internal:5080/ingest/user/pending -H "Authorization: Bearer $TOKEN"                                     
{                                                                                                                                                                                       
  "results": [                                                                                                                                                                          
    "site_admin@test.ca"                                                                                                                                                                
  ]                                                                                                                                                                                     
}
```
- Request API access with the following:
```
(candig) 17:24 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ curl -X POST candig.docker.internal:5080/ingest/user/pending/request -H "Authorization: Bearer $TOKEN"
{
  "pending_users": {
    "site_admin@test.ca": {
      "programs": {},
      "user": {
        "sample_jwt": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI1TmV3UzNaTG5fXzhJWFBqMVBtcWxfcHlzT0dXYmhDX2VQX1BPWHlqVDMwIn0.eyJleHAiOjE3MzQ1NjA5NjYsImlhdCI6MTczNDU2MDY2NiwianRpIjoiM2NhODQzYjktMTRlOS00ODUzLTkyNWYtMGFkYTA5MTFmNzg4IiwiaXNzIjoiaHR0cDovL2NhbmRpZy5kb2NrZXIuaW50ZXJuYWw6ODA4MC9hdXRoL3JlYWxtcy9jYW5kaWciLCJhdWQiOlsibG9jYWxfY2FuZGlnIiwiYWNjb3VudCJdLCJzdWIiOiI1YThhMGU1Yi00MzhmLTQ2ODEtYWI5YS0yMzBjNTM2OTYwOGEiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJsb2NhbF9jYW5kaWciLCJzZXNzaW9uX3N0YXRlIjoiNGI5MDlmMTYtYWI4Yi00NjQ3LTlkMzYtY2YxYjBmYWJmYTQ3IiwiYWNyIjoiMSIsImFsbG93ZWQtb3JpZ2lucyI6WyJodHRwOi8vY2FuZGlnLmRvY2tlci5pbnRlcm5hbDo1MDgwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLWNhbmRpZyIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXX0sInJlc291cmNlX2FjY2VzcyI6eyJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19LCJzY29wZSI6Im9wZW5pZCBwcm9maWxlIGVtYWlsIiwic2lkIjoiNGI5MDlmMTYtYWI4Yi00NjQ3LTlkMzYtY2YxYjBmYWJmYTQ3IiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJuYW1lIjoiU2l0ZSBBZG1pbiIsInByZWZlcnJlZF91c2VybmFtZSI6InNpdGVfYWRtaW5AdGVzdC5jYSIsImdpdmVuX25hbWUiOiJTaXRlIiwiZmFtaWx5X25hbWUiOiJBZG1pbiIsImVtYWlsIjoic2l0ZV9hZG1pbkB0ZXN0LmNhIn0.JK7uSqqv_yKu05omTZbord30Ll8GFx-sMfwMczQW7Pa3UPU3yJV67Jkdz9K3zxhgsggGNcZmPc0K9l5tmKgLletqcdm3xzYuYIsBwB5cohdblEzeWsazn8ftnZLHstuME1lrel7UMMCMVaUACXhuv6qLIYkpe1jcnfRlDcYGlLCrJgmz6YBx5KdP8JZHKUrtlUidMmZOylZL7w1JYrvUp5Z2i0fNvR6RE-gImk0XkNvKVJNO4MROkMKbc9GSChkWXk0piPfnsVmKF9MFFFPXwh-SyyFrrWCuCU1l28trt8Vw-VS6v4m-q9Hm8pnfXkpW8XjVfCFt6Ip4fPHGbb6Cbw",
        "user_name": "site_admin@test.ca"
      }
    }
  }
}
```

- Authorize the pending user like so:
```
(candig) 17:17 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ curl -X POST candig.docker.internal:5080/ingest/user/pending/site_admin@test.ca -H "Authorization: Bearer $TOKEN"
{
  "pending_users": {}
}
```
- You should now be authorized. This is easily tested with the upper CanDIG PR https://github.com/CanDIG/CanDIGv2/pull/914

[DIG-1857]: https://candig.atlassian.net/browse/DIG-1857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ