### PR TITLE
hotfix: bump authx to v2.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.32.2
 requests-mock>=1.12.1
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.1
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.2
 clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.1.0
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1


### PR DESCRIPTION
Pick up fix in https://github.com/CanDIG/candigv2-authx/pull/39