### PR TITLE
DIG-1923, DIG-1905: Ingest status improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,12 @@ jobs:
         python-version: ["3.12"]
     env:
       CANDIG_URL: "http://localhost"
+      HTSGET_URL: "http://localhost/genomics"
+      VAULT_URL: "http://localhost/vault"
       IS_TESTING: true
+      SERVICE_NAME: "candig-ingest"
+      APPROLE_TOKEN_FILE: ${{github.workspace}}/approle-token
+      ROLE_ID_FILE: ${{github.workspace}}/roleid
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -21,6 +26,10 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
+      - name: Add files
+        run: |
+          echo "sdfsdfs" > ${{ env.APPROLE_TOKEN_FILE }}
+          echo "sdfsdfs" > ${{ env.ROLE_ID_FILE }}
       - name: Test with pytest
         run: |
           pytest

--- a/daemon.py
+++ b/daemon.py
@@ -8,9 +8,6 @@ from katsu_ingest import ingest_schemas
 from htsget_ingest import htsget_ingest
 
 
-KATSU_URL = os.environ.get("KATSU_URL")
-
-
 logger = CanDIGLogger(__file__)
 
 initialize()

--- a/daemon.py
+++ b/daemon.py
@@ -27,7 +27,7 @@ def ingest_file(file_path):
                 programs = list(json_data.keys())
                 for program_id in programs:
                     try:
-                        ingest_results, status_code = ingest_schemas(json_data[program_id]["schemas"])
+                        ingest_results, status_code = ingest_schemas(json_data[program_id]["schemas"], results_path=results_path, result_dict=results, program_id=program_id)
                         results[program_id] = ingest_results
                     except Exception as e:
                         results[program_id] = f"Exception: {type(e)} {str(e)}"

--- a/daemon.py
+++ b/daemon.py
@@ -43,6 +43,7 @@ def ingest_file(file_path):
                         results[program_id] = ingest_results
                     except Exception as e:
                         results[program_id] = f"Exception: {type(e)} {str(e)}"
+            results["complete"] = True
         os.remove(file_path)
     except Exception as e:
         message = f"Couldn't load data from {file_path}: {type(e)} {str(e)}"

--- a/daemon.py
+++ b/daemon.py
@@ -39,7 +39,7 @@ def ingest_file(file_path):
                 programs = list(json_data.keys())
                 for program_id in programs:
                     try:
-                        ingest_results, status_code = htsget_ingest(json_data[program_id], do_not_index)
+                        ingest_results, status_code = htsget_ingest(json_data[program_id], do_not_index=do_not_index, results_path=results_path, result_dict=results)
                         results[program_id] = ingest_results
                     except Exception as e:
                         results[program_id] = f"Exception: {type(e)} {str(e)}"

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -52,6 +52,8 @@ def link_genomic_data(sample, do_not_index=False):
 
     # add GenomicDataDrsObject to contents
     response = add_file_drs_object(genomic_drs_obj, sample["main"], sample["metadata"]["data_type"], headers)
+    result["name"] = response["name"]
+    result["id"] = response["id"]
     if "error" in response:
         result["errors"].append(response["error"])
         return result
@@ -146,16 +148,17 @@ def add_file_drs_object(genomic_drs_obj, file, type, headers):
         "program": genomic_drs_obj["program"],
         "version": "v1"
     }
-    access_method = get_access_method(file["access_method"])
-    if access_method is not None:
-        if "message" in access_method:
-            return {"error": access_method["message"]}
-        obj["access_methods"].append(access_method)
     contents_obj = {
         "name": file["name"],
         "id": type,
         "drs_uri": [f"{DRS_HOST_URL}/{file['name']}"]
     }
+    access_method = get_access_method(file["access_method"])
+    if access_method is not None:
+        if "message" in access_method:
+            contents_obj["error"] = access_method["message"]
+            return contents_obj
+        obj["access_methods"].append(access_method)
 
     # is this file already in the master object? If so, replace it:
     not_found = True
@@ -169,7 +172,7 @@ def add_file_drs_object(genomic_drs_obj, file, type, headers):
         genomic_drs_obj["contents"].append(contents_obj)
     response = requests.post(url, json=obj, headers=headers)
     if response.status_code > 200:
-        return {"error": f"error creating file drs object: {response.status_code} {response.text}"}
+        contents_obj["error"] =  f"error creating file drs object: {response.status_code} {response.text}"
     return contents_obj
 
 
@@ -223,7 +226,6 @@ def parse_s3_url(url):
 
 def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dict=None):
     result = {
-        "errors": {},
         "results": []
     }
     program_ids = set()
@@ -235,18 +237,15 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
 
         logger.debug(f"Ingesting {sample['genomic_file_id']}, do_not_index = {do_not_index}")
         program_ids.add(sample["program_id"])
-        result["results"].append(f"processing genomic file {sample["genomic_file_id"]}...")
+        result["results"].append(f"processing experiment {sample["genomic_file_id"]}...")
 
         if results_path is not None and result_dict is not None:
             with open(results_path, "w") as f:
                 json.dump(result_dict, f)
 
-        if sample["genomic_file_id"] not in result["errors"]:
-            result["errors"][sample["genomic_file_id"]] = []
-
         # create the corresponding DRS objects
         if "samples" not in sample or len(sample["samples"]) == 0:
-            result["errors"][sample["genomic_file_id"]].append("No samples were specified for the genomic file mapping")
+            result["results"][-1] = f"error processing experiment {sample["genomic_file_id"]}: No samples were specified"
             break
         response = link_genomic_data(sample, do_not_index)
 
@@ -255,18 +254,17 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
 
         if len(response["errors"]) > 0:
             for err in response["errors"]:
-                result["errors"][sample["genomic_file_id"]].append(err)
                 if "403" in err:
                     status_code = 403
                     break
-        if len(result["errors"][sample["genomic_file_id"]]) == 0:
-            result["errors"].pop(sample["genomic_file_id"])
-        response.pop("errors")
+                result["results"].append(f"error processing {response["id"]} {response["name"]} in experiment {sample["genomic_file_id"]}: {err}")
+        else:
+            result["results"].append(f"processed {response["id"]} {response["name"]} for experiment {sample["genomic_file_id"]}")
+
         if "to_index" in response:
             to_index.extend(response.pop("to_index"))
-        if len(response) > 0:
-            for key in response.keys():
-                result["results"].append(f"wrote {key} to genomic file {sample["genomic_file_id"]}")
+
+    result["errors"] = []
     # Use service token to authenticate this with htsget
     headers = {}
     if not IS_TESTING:
@@ -296,7 +294,7 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
                 if len(sample['transcriptomes']) > 0:
                     statistics[program_id]['transcriptomes'] += 1
         else:
-            result["errors"] = f"Could not collect completeness stats for program: {response.text}"
+            result["errors"].append(f"Could not collect completeness stats for program: {response.text}")
 
     for program_id in statistics:
         # get the program
@@ -307,9 +305,13 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
             program["statistics"] = statistics[program_id]
             response = requests.post(url, headers=headers, json=program)
             if response.status_code != 200:
-                result["errors"] = f"Could not add statistics for program: {response.text}"
+                result["errors"].append(f"Could not add statistics for program: {response.text}")
         else:
-            result["errors"] = f"Could not add statistics for program: {response.text}"
+            result["errors"].append(f"Could not add statistics for program: {response.text}")
+
+    if len(result["errors"]) == 0:
+        result.pop("errors")
+
     return result, status_code
 
 

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -94,7 +94,7 @@ def link_genomic_data(sample, do_not_index=False):
         # update the sample_drs_object in the database:
         response = requests.post(f"{url}", json=sample_drs_obj, headers=headers)
         if response.status_code != 200:
-            result["errors"].append({"error": f"error creating sample drs object {sample_drs_obj['id']}: {response.status_code} {response.text}"})
+            result["errors"].append(f"error creating sample drs object {sample_drs_obj['id']}: {response.status_code} {response.text}")
         else:
             result["sample"].append(response.json())
 
@@ -119,7 +119,7 @@ def link_genomic_data(sample, do_not_index=False):
     # finally, post the genomic_drs_object
     response = requests.post(url, json=genomic_drs_obj, headers=headers)
     if response.status_code != 200:
-        result["errors"].append({"error": f"error posting genomic drs object {genomic_drs_obj['id']}: {response.status_code} {response.text}"})
+        result["errors"].append(f"error posting genomic drs object {genomic_drs_obj['id']}: {response.status_code} {response.text}")
     else:
         result["genomic"] = response.json()
 
@@ -129,9 +129,9 @@ def link_genomic_data(sample, do_not_index=False):
 
     response = requests.get(verify_url, headers=headers)
     if response.status_code != 200:
-        result["errors"].append({"error": f"could not verify sample: {response.text}"})
+        result["errors"].append(f"could not verify sample: {response.text}")
     elif not response.json()['result']:
-        result["errors"].append({"error": f"could not verify sample: {response.json()['message']}"})
+        result["errors"].append(f"could not verify sample: {response.json()['message']}")
     else:
         # flag the genomic_drs_object for indexing:
         logger.debug(f"Are we indexing? do_not_index = {do_not_index}")
@@ -217,7 +217,7 @@ def parse_s3_url(url):
     raise Exception(f"URI {url} cannot be parsed as an S3-style URI")
 
 
-def htsget_ingest(ingest_json, do_not_index=False):
+def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dict=None):
     result = {
         "errors": {},
         "results": {}
@@ -226,9 +226,17 @@ def htsget_ingest(ingest_json, do_not_index=False):
     to_index = []
     status_code = 200
     for sample in ingest_json:
+        if result_dict is not None and sample["program_id"] not in result_dict:
+            result_dict[sample["program_id"]] = result
+
         logger.debug(f"Ingesting {sample['genomic_file_id']}, do_not_index = {do_not_index}")
         program_ids.add(sample["program_id"])
+        if results_path is not None and result_dict is not None:
+            with open(results_path, "w") as f:
+                json.dump(result_dict, f)
+
         result["errors"][sample["genomic_file_id"]] = []
+
         # create the corresponding DRS objects
         if "samples" not in sample or len(sample["samples"]) == 0:
             result["errors"][sample["genomic_file_id"]].append("No samples were specified for the genomic file mapping")

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -215,11 +215,15 @@ def parse_s3_url(url):
                 "object": bucket_parse.group(2)
             }
             # check existence of credential for this:
-            response, status_code = get_s3_url(s3_endpoint=data["endpoint"], bucket=data["bucket"], object_id=data["object"], access_key=None, secret_key=None, region=None, public=False)
+            object = data["object"].split("?public=")
+            data["object"] = object[0]
+            if len(object) > 1:
+                data["object"] = object[0]
+                response, status_code = get_s3_url(s3_endpoint=data["endpoint"], bucket=data["bucket"], object_id=data["object"], access_key=None, secret_key=None, region=None, public=True)
+            else:
+                response, status_code = get_s3_url(s3_endpoint=data["endpoint"], bucket=data["bucket"], object_id=data["object"], access_key=None, secret_key=None, region=None, public=False)
+
             if status_code == 500:
-                # check to see if it is a public url
-                response2, status_code = get_s3_url(s3_endpoint=data["endpoint"], bucket=data["bucket"], object_id=data["object"], access_key=None, secret_key=None, region=None, public=True)
-                if status_code == 500:
                     raise Exception(response["error"])
             return data
         raise Exception(f"S3 URI {url} does not contain a bucket name")

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -63,7 +63,6 @@ def link_genomic_data(sample, do_not_index=False):
             result["errors"].append(response["error"])
             return result
 
-    result["sample"] = []
     for clin_sample in sample["samples"]:
         # for each sample in the samples, get the SampleDrsObject or create it
         sample_drs_obj = {
@@ -97,8 +96,6 @@ def link_genomic_data(sample, do_not_index=False):
         if response.status_code != 200:
             result["errors"].append(f"error creating sample drs object {sample_drs_obj['id']}: {response.status_code} {response.text}")
             return result
-        else:
-            result["sample"].append(response.json())
 
         # then add the sample to the GenomicDrsObject's contents, if it's not already there:
         contents_obj = {
@@ -115,16 +112,12 @@ def link_genomic_data(sample, do_not_index=False):
                     break
         if not_found:
             genomic_drs_obj["contents"].append(contents_obj)
-    if len(result["sample"]) == 0:
-            result.pop("sample")
 
     # finally, post the genomic_drs_object
     response = requests.post(url, json=genomic_drs_obj, headers=headers)
     if response.status_code != 200:
         result["errors"].append(f"error posting genomic drs object {genomic_drs_obj['id']}: {response.status_code} {response.text}")
         return result
-    else:
-        result["genomic"] = response.json()
 
     # verify that the genomic file exists and is readable
     verify_url = f"{HTSGET_URL}/htsget/v1/{sample['metadata']['data_type']}s/{genomic_drs_obj['id']}/verify"

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -220,7 +220,7 @@ def parse_s3_url(url):
 def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dict=None):
     result = {
         "errors": {},
-        "results": {}
+        "results": []
     }
     program_ids = set()
     to_index = []
@@ -231,6 +231,8 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
 
         logger.debug(f"Ingesting {sample['genomic_file_id']}, do_not_index = {do_not_index}")
         program_ids.add(sample["program_id"])
+        result["results"].append(f"creating genomic file {sample["genomic_file_id"]}...")
+
         if results_path is not None and result_dict is not None:
             with open(results_path, "w") as f:
                 json.dump(result_dict, f)
@@ -252,7 +254,7 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
         response.pop("errors")
         to_index.extend(response["to_index"])
         if len(response) > 0:
-            result["results"][sample["genomic_file_id"]] = response
+            result["results"][-1] = f"created genomic file {sample["genomic_file_id"]}"
     # Use service token to authenticate this with htsget
     headers = {}
     if not IS_TESTING:

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -1,6 +1,6 @@
 import argparse
 
-from authx.auth import get_site_admin_token, is_action_allowed_for_program, create_service_token, get_program_in_opa
+from authx.auth import get_site_admin_token, is_action_allowed_for_program, create_service_token, get_program_in_opa, get_s3_url
 import os
 import re
 import json
@@ -208,11 +208,19 @@ def parse_s3_url(url):
         endpoint = s3_url_parse.group(1)
         bucket_parse = re.match(r"(.+?)\/(.+)", s3_url_parse.group(4))
         if bucket_parse is not None:
-            return {
+            data = {
                 "endpoint": endpoint,
                 "bucket": bucket_parse.group(1),
                 "object": bucket_parse.group(2)
             }
+            # check existence of credential for this:
+            response, status_code = get_s3_url(s3_endpoint=data["endpoint"], bucket=data["bucket"], object_id=data["object"], access_key=None, secret_key=None, region=None, public=False)
+            if status_code == 500:
+                # check to see if it is a public url
+                response2, status_code = get_s3_url(s3_endpoint=data["endpoint"], bucket=data["bucket"], object_id=data["object"], access_key=None, secret_key=None, region=None, public=True)
+                if status_code == 500:
+                    raise Exception(response["error"])
+            return data
         raise Exception(f"S3 URI {url} does not contain a bucket name")
     raise Exception(f"URI {url} cannot be parsed as an S3-style URI")
 

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -25,8 +25,7 @@ IS_TESTING = os.getenv("IS_TESTING", False)
 def link_genomic_data(sample, do_not_index=False):
     url = f"{HTSGET_URL}/ga4gh/drs/v1/objects"
     result = {
-        "errors": [],
-        "to_index": []
+        "errors": []
     }
 
     # Use service token to authenticate this with htsget
@@ -129,7 +128,6 @@ def link_genomic_data(sample, do_not_index=False):
 
     # verify that the genomic file exists and is readable
     verify_url = f"{HTSGET_URL}/htsget/v1/{sample['metadata']['data_type']}s/{genomic_drs_obj['id']}/verify"
-    logger.debug(f"{sample['genomic_file_id']} Are we indexing? do_not_index = {do_not_index}")
 
     response = requests.get(verify_url, headers=headers)
     if response.status_code != 200:
@@ -140,9 +138,8 @@ def link_genomic_data(sample, do_not_index=False):
         return result
     else:
         # flag the genomic_drs_object for indexing:
-        logger.debug(f"Are we indexing? do_not_index = {do_not_index}")
         url =f"{HTSGET_URL}/htsget/v1/{sample['metadata']['data_type']}s/{genomic_drs_obj['id']}/index"
-        result["to_index"].append(url)
+        result["to_index"] = [url]
     return result
 
 
@@ -268,7 +265,8 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
         if len(result["errors"][sample["genomic_file_id"]]) == 0:
             result["errors"].pop(sample["genomic_file_id"])
         response.pop("errors")
-        to_index.extend(response["to_index"])
+        if "to_index" in response:
+            to_index.extend(response.pop("to_index"))
         if len(response) > 0:
             result["results"][-1] = f"created genomic file {sample["genomic_file_id"]}"
     # Use service token to authenticate this with htsget

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -55,12 +55,14 @@ def link_genomic_data(sample, do_not_index=False):
     response = add_file_drs_object(genomic_drs_obj, sample["main"], sample["metadata"]["data_type"], headers)
     if "error" in response:
         result["errors"].append(response["error"])
+        return result
 
     if "index" in sample:
         # add GenomicIndexDrsObject to contents
         response = add_file_drs_object(genomic_drs_obj, sample["index"], "index", headers)
         if "error" in response:
             result["errors"].append(response["error"])
+            return result
 
     result["sample"] = []
     for clin_sample in sample["samples"]:
@@ -95,6 +97,7 @@ def link_genomic_data(sample, do_not_index=False):
         response = requests.post(f"{url}", json=sample_drs_obj, headers=headers)
         if response.status_code != 200:
             result["errors"].append(f"error creating sample drs object {sample_drs_obj['id']}: {response.status_code} {response.text}")
+            return result
         else:
             result["sample"].append(response.json())
 
@@ -120,6 +123,7 @@ def link_genomic_data(sample, do_not_index=False):
     response = requests.post(url, json=genomic_drs_obj, headers=headers)
     if response.status_code != 200:
         result["errors"].append(f"error posting genomic drs object {genomic_drs_obj['id']}: {response.status_code} {response.text}")
+        return result
     else:
         result["genomic"] = response.json()
 
@@ -130,8 +134,10 @@ def link_genomic_data(sample, do_not_index=False):
     response = requests.get(verify_url, headers=headers)
     if response.status_code != 200:
         result["errors"].append(f"could not verify sample: {response.text}")
+        return result
     elif not response.json()['result']:
         result["errors"].append(f"could not verify sample: {response.json()['message']}")
+        return result
     else:
         # flag the genomic_drs_object for indexing:
         logger.debug(f"Are we indexing? do_not_index = {do_not_index}")
@@ -245,18 +251,20 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
             with open(results_path, "w") as f:
                 json.dump(result_dict, f)
 
-        result["errors"][sample["genomic_file_id"]] = []
+        if sample["genomic_file_id"] not in result["errors"]:
+            result["errors"][sample["genomic_file_id"]] = []
 
         # create the corresponding DRS objects
         if "samples" not in sample or len(sample["samples"]) == 0:
             result["errors"][sample["genomic_file_id"]].append("No samples were specified for the genomic file mapping")
             break
         response = link_genomic_data(sample, do_not_index)
-        for err in response["errors"]:
-            result["errors"][sample["genomic_file_id"]].append(err)
-            if "403" in err:
-                status_code = 403
-                break
+        if len(response["errors"]) > 0:
+            for err in response["errors"]:
+                result["errors"][sample["genomic_file_id"]].append(err)
+                if "403" in err:
+                    status_code = 403
+                    break
         if len(result["errors"][sample["genomic_file_id"]]) == 0:
             result["errors"].pop(sample["genomic_file_id"])
         response.pop("errors")

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -120,6 +120,8 @@ def link_genomic_data(sample, do_not_index=False):
     if response.status_code != 200:
         result["errors"].append(f"error posting genomic drs object {genomic_drs_obj['id']}: {response.status_code} {response.text}")
         return result
+    else:
+        result["sample"] = f"connected submitter_sample_id {contents_obj["name"]} to genomic_file_sample_id {contents_obj["id"]}"
 
     # verify that the genomic file exists and is readable
     verify_url = f"{HTSGET_URL}/htsget/v1/{sample['metadata']['data_type']}s/{genomic_drs_obj['id']}/verify"
@@ -260,6 +262,8 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
                 result["results"].append(f"error processing {response["id"]} {response["name"]} in experiment {sample["genomic_file_id"]}: {err}")
         else:
             result["results"].append(f"processed {response["id"]} {response["name"]} for experiment {sample["genomic_file_id"]}")
+            if "sample" in response:
+                result["results"].append(response["sample"])
 
         if "to_index" in response:
             to_index.extend(response.pop("to_index"))

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -242,7 +242,7 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
 
         logger.debug(f"Ingesting {sample['genomic_file_id']}, do_not_index = {do_not_index}")
         program_ids.add(sample["program_id"])
-        result["results"].append(f"creating genomic file {sample["genomic_file_id"]}...")
+        result["results"].append(f"processing genomic file {sample["genomic_file_id"]}...")
 
         if results_path is not None and result_dict is not None:
             with open(results_path, "w") as f:
@@ -256,6 +256,10 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
             result["errors"][sample["genomic_file_id"]].append("No samples were specified for the genomic file mapping")
             break
         response = link_genomic_data(sample, do_not_index)
+
+        # remove the temporary "processing..." message
+        result["results"].pop()
+
         if len(response["errors"]) > 0:
             for err in response["errors"]:
                 result["errors"][sample["genomic_file_id"]].append(err)
@@ -268,7 +272,8 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
         if "to_index" in response:
             to_index.extend(response.pop("to_index"))
         if len(response) > 0:
-            result["results"][-1] = f"created genomic file {sample["genomic_file_id"]}"
+            for key in response.keys():
+                result["results"].append(f"wrote {key} to genomic file {sample["genomic_file_id"]}")
     # Use service token to authenticate this with htsget
     headers = {}
     if not IS_TESTING:

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -69,6 +69,7 @@ paths:
     parameters:
       - in: path
         name: role_type
+        description: Defined site roles for this CanDIG node. By default, admin and curator are defined.
         schema:
           type: string
         required: true
@@ -104,6 +105,7 @@ paths:
     parameters:
       - in: path
         name: role_type
+        description: Defined site roles for this CanDIG node. By default, admin and curator are defined.
         schema:
           type: string
         required: true

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -86,21 +86,6 @@ paths:
                 type: array
                 items:
                   type: string
-    post:
-      summary: Assign users to role
-      description: Assign users to role
-      operationId: ingest_operations.update_role
-      requestBody:
-        $ref: "#/components/requestBodies/RoleTypeRequest"
-      responses:
-        200:
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: string
   /site-role/{role_type}/user_id/{user_id}:
     parameters:
       - in: path

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -470,7 +470,13 @@ paths:
       operationId: ingest_operations.get_ingest_status
       responses:
         200:
-          description: Success
+          description: Ingest in progress
+          content:
+            application/json:
+              schema:
+                type: object
+        201:
+          description: Ingest completed
           content:
             application/json:
               schema:

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -91,9 +91,12 @@ async def add_s3_credential():
         return {"error": "Not authorized to store aws credentials"}, 403
 
     # test endpoint before storing:
-    response, status_code = authx.auth.get_s3_url(object_id=None, s3_endpoint=data["endpoint"], bucket=data["bucket"], access_key=data["access_key"], secret_key=data["secret_key"])
-    if status_code == 200:
+    response, status_code = authx.auth.get_s3_url(object_id="None", s3_endpoint=data["endpoint"], bucket=data["bucket"], access_key=data["access_key"], secret_key=data["secret_key"])
+    # we won't actually get an s3 url because we have no object:
+    # we should expect the error to be a KeyError on the object_id of None.
+    if status_code == 500 and "object_name: None" in response["error"]:
         response, status_code = authx.auth.store_aws_credential(endpoint=data["endpoint"], bucket=data["bucket"], access=data["access_key"], secret=data["secret_key"])
+        return response, status_code
     return response, 400
 
 

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -241,6 +241,9 @@ def get_ingest_status(queue_id):
         with open(results_path) as f:
             json_data = json.load(f)
             # os.remove(results_path)
+            if "complete" in json_data:
+                json_data.pop("complete")
+                return json_data, 201
             return json_data, 200
     except:
         return {"error": f"no such queue_id {queue_id}"}, 404

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -524,7 +524,7 @@ def list_authz_for_user(user_id):
                 user_result["site_roles"].append(role_type)
 
     user_result["program_authorizations"] = {}
-    opa_permissions, status_code = authx.auth.get_opa_permissions(bearer_token=token, user_token=user_result["userinfo"]["sample_jwt"])
+    opa_permissions, opa_status_code = authx.auth.get_opa_permissions(bearer_token=token, user_token=user_result["userinfo"]["sample_jwt"])
     if status_code == 200:
         user_result["program_authorizations"]["team_member"] = opa_permissions["team_member_programs"]
         user_result["program_authorizations"]["program_curator"] = opa_permissions["curator_programs"]

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -90,7 +90,11 @@ async def add_s3_credential():
     if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/s3-credential", program=None):
         return {"error": "Not authorized to store aws credentials"}, 403
 
-    return authx.auth.store_aws_credential(endpoint=data["endpoint"], bucket=data["bucket"], access=data["access_key"], secret=data["secret_key"])
+    # test endpoint before storing:
+    response, status_code = authx.auth.get_s3_url(object_id=None, s3_endpoint=data["endpoint"], bucket=data["bucket"], access_key=data["access_key"], secret_key=data["secret_key"])
+    if status_code == 200:
+        response, status_code = authx.auth.store_aws_credential(endpoint=data["endpoint"], bucket=data["bucket"], access=data["access_key"], secret=data["secret_key"])
+    return response, 400
 
 
 @app.route('/s3-credential/endpoint/<path:endpoint_id>/bucket/<path:bucket_id>')

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -135,20 +135,6 @@ def list_role(role_type):
         return {"error": str(e)}, 500
 
 
-@app.route('/site-role/<path:role_type>')
-async def update_role(role_type):
-    role_members = await connexion.request.json()
-    try:
-        token = connexion.request.headers['Authorization'].split("Bearer ")[1]
-        if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/site-role", program=None):
-            return {"error": f"User not authorized to update site roles"}, 403
-
-        result, status_code = authx.auth.set_role_type_in_opa(role_type, role_members)
-        return result, status_code
-    except Exception as e:
-        return {"error": str(e)}, 500
-
-
 @app.route('/site-role/<path:role_type>/user_id/<path:user_id>')
 def is_user_in_role(role_type, user_id):
     try:

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -192,6 +192,8 @@ def remove_user_from_role(role_type, user_id):
         result, status_code = authx.auth.get_role_type_in_opa(role_type)
         if status_code == 200:
             if user_id in result[role_type]:
+                if role_type == "admin" and len(result[role_type]) == 1:
+                    return {"error": "You cannot remove the only site administrator. Add a new site admin before removing this user from the role."}
                 result[role_type].remove(user_id)
                 result, status_code = authx.auth.set_role_type_in_opa(role_type, result[role_type])
             else:

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -229,9 +229,6 @@ def prepare_clinical_data_for_ingest(ingest_json):
         errors = by_program[program_id]["errors"]
         logger.info(f"Validating input for program {program_id}")
         schema.validate_ingest_map(by_program[program_id])
-        if len(schema.validation_warnings) > 0:
-            logger.info("Validation returned warnings:")
-            logger.info("\n".join(schema.validation_warnings))
         if len(schema.validation_errors) > 0:
             errors.append([str(line) for line in schema.validation_errors])
             continue

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -53,8 +53,11 @@ def read_json(file_path):
 
 
 ## This will be called by the daemon
-def ingest_schemas(fields, batch_size=1000):
+def ingest_schemas(fields, batch_size=1000, results_path=None, result_dict=None, program_id=None):
     result = {"errors": [], "results": []}
+
+    if result_dict is not None and program_id is not None:
+            result_dict[program_id] = result
 
     # Use service token to authenticate this with katsu
     headers = {
@@ -102,6 +105,10 @@ def ingest_schemas(fields, batch_size=1000):
             result["results"].append(
                 f"Of {total_count} {type}, {created_count} were created"
             )
+        if results_path is not None and result_dict is not None:
+            with open(results_path, "w") as f:
+                json.dump(result_dict, f)
+
     return result, response.status_code
 
 

--- a/katsu_ingest.py
+++ b/katsu_ingest.py
@@ -102,9 +102,10 @@ def ingest_schemas(fields, batch_size=1000, results_path=None, result_dict=None,
                     if type == "programs" and "unique" in response.text:
                         # this is still okay to return 200:
                         return result, 200
-            result["results"].append(
-                f"Of {total_count} {type}, {created_count} were created"
-            )
+            if type != "programs": # don't update about program; this seems redundant
+                result["results"].append(
+                    f"Of {total_count} {type}, {created_count} were created"
+                )
         if results_path is not None and result_dict is not None:
             with open(results_path, "w") as f:
                 json.dump(result_dict, f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.32.2
 requests-mock>=1.12.1
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.7.0
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.7.1
 clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.1.0
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -47,6 +47,8 @@ def test_htsget_ingest(requests_mock):
     requests_mock.get(matcher, json={"data": {"client_token": "sfsfd"}}, status_code=200)
     requests_mock.post(matcher, json={"data": {"client_token": "sfsfd"}}, status_code=200)
 
+    matcher = re.compile(f"{VAULT_URL}/v1/candig-ingest/aws/.+")
+    requests_mock.get(matcher, json={"data": {"endpoint": "sfsfd", "bucket": "1000genomes", "access_key": "sfsdf", "secret_key": "sdfsfs", "url": "s3.us-east-1.amazonaws.com", "secure": "False"}}, status_code=200)
 
     headers = {"Authorization": f"Bearer test", "Content-Type": "application/json"}
     with open("tests/genomic_ingest.json", "r") as f:
@@ -55,11 +57,8 @@ def test_htsget_ingest(requests_mock):
             response = htsget_ingest.link_genomic_data(sample)
             print(json.dumps(response, indent=4))
             assert len(response["errors"]) == 0
-            assert "genomic" in response
-            assert len(response["genomic"]["contents"]) == 2 + len(sample["samples"])
+            assert "name" in response
             assert "sample" in response
-            assert len(response["sample"]) == len(sample["samples"])
-            assert len(response["sample"][0]["contents"]) == 1
 
     # bad sample:
     bad_s3_sample = {
@@ -87,4 +86,4 @@ def test_htsget_ingest(requests_mock):
     }
     response = htsget_ingest.link_genomic_data(bad_s3_sample)
     print(json.dumps(response, indent=4))
-    assert len(response["errors"]) == 2
+    assert len(response["errors"]) == 1


### PR DESCRIPTION
Fixed ingest statuses:
* Adding an s3 credential now validates the credential before storing it: if you try to ingest a bad endpoint, like
```
## s3 dev server
curl -X "POST" "http://candig.docker.internal:5080/ingest/s3-credential" \
     -H 'Authorization: Bearer <site admin token>' \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "endpoint": "http://minio:9000",
  "bucket": "test-genomic",
  "access_key": "xxx",
  "secret_key": "xxx"
}'
```
you should get some sort of 400 error.

* Getting status for an ingest gives you more detailed results. As you refresh, you should get some more information about the progress of the ingest. The status endpoint will return 200 while ingest is still in progress and 201 Created when it's complete.
* Htsget ingest gives more informative results. Errors are more detailed and will prevent the ingest of that particular item from proceeding. If the S3 url cannot be reached, that item's ingest will error out.

Example output:
```
{
  "SYNTH_01": {
    "results": [
      "error processing variant 188v2-2.vcf.gz in experiment 188v2-2: {'error': 'Vault error: could not get credential for endpoint s3_amazonaws_com and bucket dhdp-site-a: {\\'error\\': \\'{\"errors\":[]}\\\\n\\'}'}",
      "error processing read NA02102.bam in experiment NA02102: HTTPConnectionPool(host='minio', port=9000): Max retries exceeded with url: /test-genomic?location= (Caused by NameResolutionError(\"<urllib3.connection.HTTPConnection object at 0xffffac5e0f80>: Failed to resolve 'minio' ([Errno -2] Name or service not known)\"))",
      "processed read NA02102.chr1.cram for experiment NA02102",
      "connected submitter_sample_id SAMPLE_0003 to genomic_file_sample_id NA02102"
    ]
  },
  "SYNTH_02": {
    "results": [
      "processed variant HG02102.vcf.gz for experiment HG02102",
      "connected submitter_sample_id SAMPLE_0801 to genomic_file_sample_id HG02102",
      "processed read NA02102.bam for experiment NA02102",
      "connected submitter_sample_id SAMPLE_0813 to genomic_file_sample_id NA02102",
      "processed read NA02102.chr1.cram for experiment NA02102",
      "connected submitter_sample_id SAMPLE_0860 to genomic_file_sample_id NA02102"
    ]
  },
  "SYNTH_03": {
    "results": [
      "processed variant HG02102.vcf.gz for experiment HG02102",
      "connected submitter_sample_id SAMPLE_1611 to genomic_file_sample_id HG02102",
      "processed read NA02102.bam for experiment NA02102",
      "connected submitter_sample_id SAMPLE_1612 to genomic_file_sample_id NA02102",
      "error processing experiment NA02102: No samples were specified"
    ]
  }
}
```