### PR TITLE
Synthetic data generates from a specific branch and katsu in the stack

### DIFF
--- a/generate_test_data.py
+++ b/generate_test_data.py
@@ -13,9 +13,11 @@ import pprint
 def parse_args():
     parser = argparse.ArgumentParser(description="A script that copies and converts data from mohccn-synthetic-data for "
                                                  "ingest into CanDIG platform.")
-    parser.add_argument("--katsu-repo", default="lib/katsu/katsu_service/chord_metadata_service/mohpackets/data",
+    parser.add_argument("--katsu-repo", default="lib/katsu/katsu_service",
                         help="Path to the katsu repo that contains jsons that should be used to generate the synth data."
                              "Default is the standard katsu repo that is part of the stack")
+    parser.add_argument("--branch", default="develop",
+                        help="branch of the synthetic data repo to check out.")
     parser.add_argument("--prefix", help="optional prefix to apply to all identifiers")
     parser.add_argument("--tmp", help="Directory to temporarily clone the mohccn-synthetic-data repo.",
                         default="tmp-data")
@@ -41,11 +43,11 @@ def main(args):
                       "destination.")
                 sys.exit()
     print(f"Cloning mohccn-synthetic-data repo into {args.tmp}")
-    synth_repo = Repo.clone_from("https://github.com/CanDIG/mohccn-synthetic-data.git", args.tmp)
+    synth_repo = Repo.clone_from("https://github.com/CanDIG/mohccn-synthetic-data.git", args.tmp, branch=args.branch)
 
     try:
         if args.prefix:
-            process = subprocess.run([f'python {args.tmp}/src/json_to_csv.py --input {args.katsu_repo} --size s'],
+            process = subprocess.run([f'python {args.tmp}/src/json_to_csv.py --input {args.katsu_repo}/chord_metadata_service/mohpackets/data --size s'],
                                      shell=True, check=True, capture_output=True)
             process = subprocess.run([f'python {args.tmp}/src/csv_to_ingest.py --size s --prefix {args.prefix}'],
                                      shell=True, check=True, capture_output=True)

--- a/generate_test_data.py
+++ b/generate_test_data.py
@@ -42,7 +42,8 @@ def main(args):
 
     try:
         if args.prefix:
-
+            process = subprocess.run([f'python {args.tmp}/src/json_to_csv.py --input lib/katsu/katsu_service/chord_metadata_service/mohpackets/data --size s'],
+                                     shell=True, check=True, capture_output=True)
             process = subprocess.run([f'python {args.tmp}/src/csv_to_ingest.py --size s --prefix {args.prefix}'],
                                      shell=True, check=True, capture_output=True)
             output_dir = f"{args.tmp}/custom_dataset_csv-{args.prefix}"

--- a/generate_test_data.py
+++ b/generate_test_data.py
@@ -13,6 +13,9 @@ import pprint
 def parse_args():
     parser = argparse.ArgumentParser(description="A script that copies and converts data from mohccn-synthetic-data for "
                                                  "ingest into CanDIG platform.")
+    parser.add_argument("--katsu-repo", default="lib/katsu/katsu_service/chord_metadata_service/mohpackets/data",
+                        help="Path to the katsu repo that contains jsons that should be used to generate the synth data."
+                             "Default is the standard katsu repo that is part of the stack")
     parser.add_argument("--prefix", help="optional prefix to apply to all identifiers")
     parser.add_argument("--tmp", help="Directory to temporarily clone the mohccn-synthetic-data repo.",
                         default="tmp-data")
@@ -42,7 +45,7 @@ def main(args):
 
     try:
         if args.prefix:
-            process = subprocess.run([f'python {args.tmp}/src/json_to_csv.py --input lib/katsu/katsu_service/chord_metadata_service/mohpackets/data --size s'],
+            process = subprocess.run([f'python {args.tmp}/src/json_to_csv.py --input {args.katsu_repo} --size s'],
                                      shell=True, check=True, capture_output=True)
             process = subprocess.run([f'python {args.tmp}/src/csv_to_ingest.py --size s --prefix {args.prefix}'],
                                      shell=True, check=True, capture_output=True)


### PR DESCRIPTION
This adds a step so that the synthetic data used for integration tests uses the json files that are in the katsu that is part of the stack. This ensures that integration tests will still pass based on the right versions that are in the stack.

* add argument for the katsu repo, default is where we expect to find it in the stack
* add argument to checkout a specific branch of the synth data repo
* add step to generate synthetic data csvs from the jsons in that repo