### PR TITLE
DIG-1939: Generate test data script uses specific commit

### DIFF
--- a/generate_test_data.py
+++ b/generate_test_data.py
@@ -13,7 +13,12 @@ import pprint
 def parse_args():
     parser = argparse.ArgumentParser(description="A script that copies and converts data from mohccn-synthetic-data for "
                                                  "ingest into CanDIG platform.")
-    parser.add_argument("--commit", help="Commit id from the MoHCCN Synthetic data repo that should be used")
+    parser.add_argument("--commit",
+                        help="The commit id of the mohccn-synthetic-data repo that should be checked out when generating"
+                             "test data")
+    parser.add_argument("--katsu-repo", default="lib/katsu/katsu_service",
+                        help="Path to the katsu repo that contains jsons that should be used to generate the synth data."
+                             "Default is the standard katsu repo that is part of the stack")
     parser.add_argument("--prefix", help="optional prefix to apply to all identifiers")
     parser.add_argument("--tmp", help="Directory to temporarily clone the mohccn-synthetic-data repo.",
                         default="tmp-data")
@@ -44,7 +49,8 @@ def main(args):
 
     try:
         if args.prefix:
-
+            process = subprocess.run([f'python {args.tmp}/src/json_to_csv.py --input {args.katsu_repo}/chord_metadata_service/mohpackets/data --size s'],
+                                     shell=True, check=True, capture_output=True)
             process = subprocess.run([f'python {args.tmp}/src/csv_to_ingest.py --size s --prefix {args.prefix}'],
                                      shell=True, check=True, capture_output=True)
             output_dir = f"{args.tmp}/custom_dataset_csv-{args.prefix}"
@@ -59,6 +65,9 @@ def main(args):
             print("Converting small_dataset_csvs to small_dataset_clinical_ingest.json")
             output_dir = f"{args.tmp}/small_dataset_csv"
             try:
+                process = subprocess.run([
+                                             f'python {args.tmp}/src/json_to_csv.py --input {args.katsu_repo}/chord_metadata_service/mohpackets/data --size s'],
+                                         shell=True, check=True, capture_output=True)
                 process = subprocess.run([f'python {args.tmp}/src/csv_to_ingest.py --size s'],
                                          shell=True, check=True, capture_output=True)
             except subprocess.CalledProcessError as e:

--- a/generate_test_data.py
+++ b/generate_test_data.py
@@ -13,6 +13,7 @@ import pprint
 def parse_args():
     parser = argparse.ArgumentParser(description="A script that copies and converts data from mohccn-synthetic-data for "
                                                  "ingest into CanDIG platform.")
+    parser.add_argument("--commit", help="Commit id from the MoHCCN Synthetic data repo that should be used")
     parser.add_argument("--prefix", help="optional prefix to apply to all identifiers")
     parser.add_argument("--tmp", help="Directory to temporarily clone the mohccn-synthetic-data repo.",
                         default="tmp-data")
@@ -39,6 +40,7 @@ def main(args):
                 sys.exit()
     print(f"Cloning mohccn-synthetic-data repo into {args.tmp}")
     synth_repo = Repo.clone_from("https://github.com/CanDIG/mohccn-synthetic-data.git", args.tmp)
+    synth_repo.git.checkout(args.commit)
 
     try:
         if args.prefix:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -91,4 +91,6 @@ def test_htsget_ingest(requests_mock):
 
 
 def test_synth_data_generation():
-
+    args={
+        
+    }

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -9,6 +9,7 @@ REPO_DIR = os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/..")
 sys.path.insert(0, os.path.abspath(f"{REPO_DIR}"))
 import katsu_ingest
 import htsget_ingest
+import generate_test_data
 
 CANDIG_URL = os.getenv("CANDIG_URL", "http://localhost")
 HTSGET_URL = os.getenv("HTSGET_URL", f"{CANDIG_URL}/genomics")
@@ -87,3 +88,7 @@ def test_htsget_ingest(requests_mock):
     response = htsget_ingest.link_genomic_data(bad_s3_sample)
     print(json.dumps(response, indent=4))
     assert len(response["errors"]) == 1
+
+
+def test_synth_data_generation():
+

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -4,13 +4,11 @@ import requests
 import os
 import re
 import sys
-from argparse import Namespace
 
 REPO_DIR = os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/..")
 sys.path.insert(0, os.path.abspath(f"{REPO_DIR}"))
 import katsu_ingest
 import htsget_ingest
-import generate_test_data
 
 CANDIG_URL = os.getenv("CANDIG_URL", "http://localhost")
 HTSGET_URL = os.getenv("HTSGET_URL", f"{CANDIG_URL}/genomics")
@@ -90,4 +88,3 @@ def test_htsget_ingest(requests_mock):
     response = htsget_ingest.link_genomic_data(bad_s3_sample)
     print(json.dumps(response, indent=4))
     assert len(response["errors"]) == 1
-

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -4,6 +4,7 @@ import requests
 import os
 import re
 import sys
+from argparse import Namespace
 
 REPO_DIR = os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/..")
 sys.path.insert(0, os.path.abspath(f"{REPO_DIR}"))
@@ -14,6 +15,7 @@ import generate_test_data
 CANDIG_URL = os.getenv("CANDIG_URL", "http://localhost")
 HTSGET_URL = os.getenv("HTSGET_URL", f"{CANDIG_URL}/genomics")
 VAULT_URL = os.getenv("VAULT_URL", f"{CANDIG_URL}/vault")
+
 
 def test_prepare_clinical_ingest():
     with open("tests/clinical_ingest.json", "r") as f:
@@ -89,8 +91,3 @@ def test_htsget_ingest(requests_mock):
     print(json.dumps(response, indent=4))
     assert len(response["errors"]) == 1
 
-
-def test_synth_data_generation():
-    args={
-        
-    }


### PR DESCRIPTION
Modifications to help keep synth data in sync with the stack:
* add arg to specify the correct commit from the mohccn-synthetic-data repo to clone
  * ensures correct manifest version and genomic json is used 
* add arg to specify the katsu repo that should be referenced
  * ensures data stays in sync with the running katsu 