### PR TITLE
DIG-1924, DIG-1925: renaming drs objects and their descriptions

### DIFF
--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -39,11 +39,11 @@ def link_genomic_data(sample, do_not_index=False):
 
     # get the master analysis object, or create it:
     analysis_drs_obj = {}
-    response = requests.get(f"{url}/{sample['genomic_file_id']}", headers=headers)
+    response = requests.get(f"{url}/{sample['analysis_id']}", headers=headers)
     if response.status_code == 200:
         analysis_drs_obj = response.json()
-    analysis_drs_obj["id"] = sample["genomic_file_id"]
-    analysis_drs_obj["name"] = sample["genomic_file_id"]
+    analysis_drs_obj["id"] = sample["analysis_id"]
+    analysis_drs_obj["name"] = sample["analysis_id"]
     analysis_drs_obj["description"] = sample["metadata"]["data_type"]
     analysis_drs_obj["program"] = sample["program_id"]
     analysis_drs_obj["reference_genome"] = sample["metadata"]["reference"]
@@ -51,7 +51,7 @@ def link_genomic_data(sample, do_not_index=False):
     if "contents" not in analysis_drs_obj:
         analysis_drs_obj["contents"] = []
 
-    # add GenomicDataDrsObject to contents
+    # add AnalysisDataDrsObject to contents
     response = add_file_drs_object(analysis_drs_obj, sample["main"], sample["metadata"]["data_type"], headers)
     result["name"] = response["name"]
     result["id"] = response["id"]
@@ -60,7 +60,7 @@ def link_genomic_data(sample, do_not_index=False):
         return result
 
     if "index" in sample:
-        # add GenomicIndexDrsObject to contents
+        # add AnalysisIndexDrsObject to contents
         response = add_file_drs_object(analysis_drs_obj, sample["index"], "index", headers)
         if "error" in response:
             result["errors"].append(response["error"])
@@ -80,17 +80,17 @@ def link_genomic_data(sample, do_not_index=False):
         if response.status_code == 200:
             sample_drs_obj = response.json()
 
-        # add the GenomicDrsObject to its contents, if it's not already there:
+        # add the AnalysisDrsObject to its contents, if it's not already there:
         not_found = True
         if len(sample_drs_obj["contents"]) > 0:
             for obj in sample_drs_obj["contents"]:
-                if obj["name"] == sample["genomic_file_id"]:
+                if obj["name"] == sample["analysis_id"]:
                     not_found = False
         if not_found:
             contents_obj = {
-                "name": sample["genomic_file_id"],
-                "id": sample["genomic_file_id"],
-                "drs_uri": [f"{DRS_HOST_URL}/{sample['genomic_file_id']}"]
+                "name": sample["analysis_id"],
+                "id": sample["analysis_id"],
+                "drs_uri": [f"{DRS_HOST_URL}/{sample['analysis_id']}"]
             }
             sample_drs_obj["contents"].append(contents_obj)
 
@@ -100,10 +100,10 @@ def link_genomic_data(sample, do_not_index=False):
             result["errors"].append(f"error creating sample drs object {sample_drs_obj['id']}: {response.status_code} {response.text}")
             return result
 
-        # then add the sample to the GenomicDrsObject's contents, if it's not already there:
+        # then add the sample to the AnalysisDrsObject's contents, if it's not already there:
         contents_obj = {
             "name": clin_sample["submitter_sample_id"],
-            "id": clin_sample["genomic_file_sample_id"],
+            "id": clin_sample["analysis_sample_id"],
             "drs_uri": [f"{DRS_HOST_URL}/{clin_sample['submitter_sample_id']}"]
         }
         not_found = True
@@ -122,7 +122,7 @@ def link_genomic_data(sample, do_not_index=False):
         result["errors"].append(f"error posting analysis drs object {analysis_drs_obj['id']}: {response.status_code} {response.text}")
         return result
     else:
-        result["sample"] = f"connected submitter_sample_id {contents_obj["name"]} to genomic_file_sample_id {contents_obj["id"]}"
+        result["sample"] = f"connected submitter_sample_id {contents_obj["name"]} to analysis_sample_id {contents_obj["id"]}"
 
     # verify that the genomic file exists and is readable
     verify_url = f"{HTSGET_URL}/htsget/v1/{sample['metadata']['data_type']}s/{analysis_drs_obj['id']}/verify"
@@ -242,9 +242,9 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
         if result_dict is not None and sample["program_id"] not in result_dict:
             result_dict[sample["program_id"]] = result
 
-        logger.debug(f"Ingesting {sample['genomic_file_id']}, do_not_index = {do_not_index}")
+        logger.debug(f"Ingesting {sample['analysis_id']}, do_not_index = {do_not_index}")
         program_ids.add(sample["program_id"])
-        result["results"].append(f"processing experiment {sample["genomic_file_id"]}...")
+        result["results"].append(f"processing experiment {sample["analysis_id"]}...")
 
         if results_path is not None and result_dict is not None:
             with open(results_path, "w") as f:
@@ -252,7 +252,7 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
 
         # create the corresponding DRS objects
         if "samples" not in sample or len(sample["samples"]) == 0:
-            result["results"][-1] = f"error processing experiment {sample["genomic_file_id"]}: No samples were specified"
+            result["results"][-1] = f"error processing experiment {sample["analysis_id"]}: No samples were specified"
             break
         response = link_genomic_data(sample, do_not_index)
 
@@ -264,9 +264,9 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
                 if "403" in err:
                     status_code = 403
                     break
-                result["results"].append(f"error processing {response["id"]} {response["name"]} in experiment {sample["genomic_file_id"]}: {err}")
+                result["results"].append(f"error processing {response["id"]} {response["name"]} in experiment {sample["analysis_id"]}: {err}")
         else:
-            result["results"].append(f"processed {response["id"]} {response["name"]} for experiment {sample["genomic_file_id"]}")
+            result["results"].append(f"processed {response["id"]} {response["name"]} for experiment {sample["analysis_id"]}")
             if "sample" in response:
                 result["results"].append(response["sample"])
 
@@ -327,7 +327,7 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
 def check_genomic_data(dataset, token):
     with open("ingest_openapi.yaml") as f:
         openapi_text = f.read()
-        json_schema = openapi_to_jsonschema(openapi_text, "GenomicSample")
+        json_schema = openapi_to_jsonschema(openapi_text, "AnalysisSample")
     result = {
         "errors": {},
     }
@@ -364,8 +364,8 @@ def check_genomic_data(dataset, token):
         for sample in by_program[program_id]:
             sample_errors = []
             # validate the json
-            if sample["genomic_file_id"] == sample["main"]["name"] or sample["genomic_file_id"] == sample["index"]["name"]:
-                sample_errors = f"Experiment {sample['genomic_file_id']} cannot have the same name as one of its files."
+            if sample["analysis_id"] == sample["main"]["name"] or sample["analysis_id"] == sample["index"]["name"]:
+                sample_errors = f"Experiment {sample['analysis_id']} cannot have the same name as one of its files."
             else:
                 for error in jsonschema.Draft202012Validator(json_schema).iter_errors(sample):
                     sample_errors.extend(f"{' > '.join(error.path)}: {error.message}")
@@ -376,7 +376,7 @@ def check_genomic_data(dataset, token):
                 if submitter_sample["submitter_sample_id"] not in samples_in_program:
                     sample_errors.append({"no such sample": f"sample {submitter_sample['submitter_sample_id']} does not exist in clinical data {samples_in_program}"})
             if len(sample_errors) > 0:
-                result["errors"][program_id].append({sample["genomic_file_id"]: sample_errors})
+                result["errors"][program_id].append({sample["analysis_id"]: sample_errors})
         if len(result["errors"][program_id]) == 0:
             result["errors"].pop(program_id)
     if len(result["errors"]) == 0:

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -44,7 +44,7 @@ def link_genomic_data(sample, do_not_index=False):
         analysis_drs_obj = response.json()
     analysis_drs_obj["id"] = sample["genomic_file_id"]
     analysis_drs_obj["name"] = sample["genomic_file_id"]
-    analysis_drs_obj["description"] = sample["metadata"]["sequence_type"]
+    analysis_drs_obj["description"] = sample["metadata"]["data_type"]
     analysis_drs_obj["program"] = sample["program_id"]
     analysis_drs_obj["reference_genome"] = sample["metadata"]["reference"]
     analysis_drs_obj["version"] = "v1"
@@ -67,11 +67,11 @@ def link_genomic_data(sample, do_not_index=False):
             return result
 
     for clin_sample in sample["samples"]:
-        # for each sample in the samples, get the SampleDrsObject or create it
+        # for each sample in the samples, get the ExperimentDrsObject or create it
         sample_drs_obj = {
             "id": clin_sample["submitter_sample_id"],
             "name": clin_sample["submitter_sample_id"],
-            "description": "sample",
+            "description": sample["metadata"]["sequence_type"],
             "program": sample["program_id"],
             "version": "v1",
             "contents": []
@@ -365,7 +365,7 @@ def check_genomic_data(dataset, token):
             sample_errors = []
             # validate the json
             if sample["genomic_file_id"] == sample["main"]["name"] or sample["genomic_file_id"] == sample["index"]["name"]:
-                sample_errors = f"Sample {sample['genomic_file_id']} cannot have the same name as one of its files."
+                sample_errors = f"Experiment {sample['genomic_file_id']} cannot have the same name as one of its files."
             else:
                 for error in jsonschema.Draft202012Validator(json_schema).iter_errors(sample):
                     sample_errors.extend(f"{' > '.join(error.path)}: {error.message}")

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -37,22 +37,22 @@ def link_genomic_data(sample, do_not_index=False):
             "Content-Type": "application/json"
         }
 
-    # get the master genomic object, or create it:
-    genomic_drs_obj = {}
+    # get the master analysis object, or create it:
+    analysis_drs_obj = {}
     response = requests.get(f"{url}/{sample['genomic_file_id']}", headers=headers)
     if response.status_code == 200:
-        genomic_drs_obj = response.json()
-    genomic_drs_obj["id"] = sample["genomic_file_id"]
-    genomic_drs_obj["name"] = sample["genomic_file_id"]
-    genomic_drs_obj["description"] = sample["metadata"]["sequence_type"]
-    genomic_drs_obj["program"] = sample["program_id"]
-    genomic_drs_obj["reference_genome"] = sample["metadata"]["reference"]
-    genomic_drs_obj["version"] = "v1"
-    if "contents" not in genomic_drs_obj:
-        genomic_drs_obj["contents"] = []
+        analysis_drs_obj = response.json()
+    analysis_drs_obj["id"] = sample["genomic_file_id"]
+    analysis_drs_obj["name"] = sample["genomic_file_id"]
+    analysis_drs_obj["description"] = sample["metadata"]["sequence_type"]
+    analysis_drs_obj["program"] = sample["program_id"]
+    analysis_drs_obj["reference_genome"] = sample["metadata"]["reference"]
+    analysis_drs_obj["version"] = "v1"
+    if "contents" not in analysis_drs_obj:
+        analysis_drs_obj["contents"] = []
 
     # add GenomicDataDrsObject to contents
-    response = add_file_drs_object(genomic_drs_obj, sample["main"], sample["metadata"]["data_type"], headers)
+    response = add_file_drs_object(analysis_drs_obj, sample["main"], sample["metadata"]["data_type"], headers)
     result["name"] = response["name"]
     result["id"] = response["id"]
     if "error" in response:
@@ -61,7 +61,7 @@ def link_genomic_data(sample, do_not_index=False):
 
     if "index" in sample:
         # add GenomicIndexDrsObject to contents
-        response = add_file_drs_object(genomic_drs_obj, sample["index"], "index", headers)
+        response = add_file_drs_object(analysis_drs_obj, sample["index"], "index", headers)
         if "error" in response:
             result["errors"].append(response["error"])
             return result
@@ -107,25 +107,25 @@ def link_genomic_data(sample, do_not_index=False):
             "drs_uri": [f"{DRS_HOST_URL}/{clin_sample['submitter_sample_id']}"]
         }
         not_found = True
-        if len(genomic_drs_obj["contents"]) > 0:
-            for i in range(0, len(genomic_drs_obj["contents"])):
-                if genomic_drs_obj["contents"][i]["name"] == clin_sample["submitter_sample_id"]:
+        if len(analysis_drs_obj["contents"]) > 0:
+            for i in range(0, len(analysis_drs_obj["contents"])):
+                if analysis_drs_obj["contents"][i]["name"] == clin_sample["submitter_sample_id"]:
                     not_found = False
-                    genomic_drs_obj["contents"][i] = contents_obj
+                    analysis_drs_obj["contents"][i] = contents_obj
                     break
         if not_found:
-            genomic_drs_obj["contents"].append(contents_obj)
+            analysis_drs_obj["contents"].append(contents_obj)
 
-    # finally, post the genomic_drs_object
-    response = requests.post(url, json=genomic_drs_obj, headers=headers)
+    # finally, post the analysis_drs_object
+    response = requests.post(url, json=analysis_drs_obj, headers=headers)
     if response.status_code != 200:
-        result["errors"].append(f"error posting genomic drs object {genomic_drs_obj['id']}: {response.status_code} {response.text}")
+        result["errors"].append(f"error posting analysis drs object {analysis_drs_obj['id']}: {response.status_code} {response.text}")
         return result
     else:
         result["sample"] = f"connected submitter_sample_id {contents_obj["name"]} to genomic_file_sample_id {contents_obj["id"]}"
 
     # verify that the genomic file exists and is readable
-    verify_url = f"{HTSGET_URL}/htsget/v1/{sample['metadata']['data_type']}s/{genomic_drs_obj['id']}/verify"
+    verify_url = f"{HTSGET_URL}/htsget/v1/{sample['metadata']['data_type']}s/{analysis_drs_obj['id']}/verify"
 
     response = requests.get(verify_url, headers=headers)
     if response.status_code != 200:
@@ -135,20 +135,20 @@ def link_genomic_data(sample, do_not_index=False):
         result["errors"].append(f"could not verify sample: {response.json()['message']}")
         return result
     else:
-        # flag the genomic_drs_object for indexing:
-        url =f"{HTSGET_URL}/htsget/v1/{sample['metadata']['data_type']}s/{genomic_drs_obj['id']}/index"
+        # flag the analysis_drs_object for indexing:
+        url =f"{HTSGET_URL}/htsget/v1/{sample['metadata']['data_type']}s/{analysis_drs_obj['id']}/index"
         result["to_index"] = [url]
     return result
 
 
-def add_file_drs_object(genomic_drs_obj, file, type, headers):
+def add_file_drs_object(analysis_drs_obj, file, type, headers):
     url = f"{HTSGET_URL}/ga4gh/drs/v1/objects"
     obj = {
         "access_methods": [],
         "id": file['name'],
         "name": file['name'],
         "description": type,
-        "program": genomic_drs_obj["program"],
+        "program": analysis_drs_obj["program"],
         "version": "v1"
     }
     contents_obj = {
@@ -165,14 +165,14 @@ def add_file_drs_object(genomic_drs_obj, file, type, headers):
 
     # is this file already in the master object? If so, replace it:
     not_found = True
-    if len(genomic_drs_obj["contents"]) > 0:
-        for i in range(0, len(genomic_drs_obj["contents"])):
-            if genomic_drs_obj["contents"][i]["name"] == file["name"]:
-                genomic_drs_obj["contents"][i] = contents_obj
+    if len(analysis_drs_obj["contents"]) > 0:
+        for i in range(0, len(analysis_drs_obj["contents"])):
+            if analysis_drs_obj["contents"][i]["name"] == file["name"]:
+                analysis_drs_obj["contents"][i] = contents_obj
                 not_found = False
                 break
     if not_found:
-        genomic_drs_obj["contents"].append(contents_obj)
+        analysis_drs_obj["contents"].append(contents_obj)
     response = requests.post(url, json=obj, headers=headers)
     if response.status_code > 200:
         contents_obj["error"] =  f"error creating file drs object: {response.status_code} {response.text}"

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -290,7 +290,7 @@ def htsget_ingest(ingest_json, do_not_index=False, results_path=None, result_dic
     # update completeness stats for program_ids with created samples
     statistics = {}
     for program_id in program_ids:
-        url = f"{HTSGET_URL}/htsget/v1/samples"
+        url = f"{HTSGET_URL}/htsget/v1/experiments"
         response = requests.get(url, headers=headers, params={"program": program_id})
         if response.status_code == 200:
             for sample in response.json():

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -404,7 +404,7 @@ paths:
           description: Success
   /genomic:
     post:
-      summary: Ingest Genomic data
+      summary: Ingest Analysis data
       description: Add linkages between clinical donors and genomic data.
       operationId: ingest_operations.add_genomic_linkages
       parameters:
@@ -415,7 +415,7 @@ paths:
             type: boolean
           description: set to true to prevent indexing of genomic files
       requestBody:
-        $ref: '#/components/requestBodies/GenomicIngestRequest'
+        $ref: '#/components/requestBodies/AnalysisIngestRequest'
       responses:
         200:
           description: Success
@@ -490,13 +490,13 @@ components:
         'application/json':
           schema:
             $ref: "#/components/schemas/S3Credential"
-    GenomicIngestRequest:
+    AnalysisIngestRequest:
       content:
         'application/json':
           schema:
             type: array
             items:
-              $ref: "#/components/schemas/GenomicSample"
+              $ref: "#/components/schemas/AnalysisSample"
     ClinicalDonorRequest:
       content:
         'application/json':
@@ -613,19 +613,19 @@ components:
           type: array
           items:
             type: string
-    GenomicSample:
+    AnalysisSample:
       type: object
       properties:
         program_id:
           type: string
           description: Name of the program this sample belongs to. The user must be authorized to add data to this program.
-        genomic_file_id:
+        analysis_id:
           type: string
-          description: A unique name for this genomic data resource
+          description: A unique name for this downstream analysis
           example: "HG00096.vcf"
         metadata:
           type: object
-          description: Additional data that describes the genomic resource
+          description: Additional data that describes the downstream analysis
           properties:
             sequence_type:
               type: string
@@ -662,7 +662,7 @@ components:
             $ref: "#/components/schemas/SampleLink"
       required:
         - program_id
-        - genomic_file_id
+        - analysis_id
         - metadata
         - main
         - index
@@ -702,13 +702,13 @@ components:
           type: string
           description: the name of the sample as listed in the linked donor data
           example: sample_registration_id_1
-        genomic_file_sample_id:
+        analysis_sample_id:
           type: string
-          description: the name of the sample in the genomic data resource
+          description: the name of the sample in the analysis
           example: TUMOUR/NORMAL/PROGRAM_SAMPLE_REGISTRATION_ID_1
       required:
         - submitter_sample_id
-        - genomic_file_sample_id
+        - analysis_sample_id
     Program:
       type: object
       description: Describes a program

--- a/tests/genomic_ingest.json
+++ b/tests/genomic_ingest.json
@@ -1,7 +1,7 @@
 [
     {
         "program_id": "SYNTH_02",
-        "genomic_file_id": "HG00096.cnv.vcf",
+        "analysis_id": "HG00096.cnv.vcf",
         "main": {
             "access_method": "http://s3.us-east-1.amazonaws.com/1000genomes/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz?public=true",
             "name": "HG00096.cnv.vcf.gz"
@@ -17,14 +17,14 @@
         },
         "samples": [
             {
-                "genomic_file_sample_id": "HG00096",
+                "analysis_sample_id": "HG00096",
                 "submitter_sample_id": "SAMPLE_0017"
             }
         ]
     },
     {
         "program_id": "SYNTH_01",
-        "genomic_file_id": "multisample_1",
+        "analysis_id": "multisample_1",
         "main": {
             "access_method": "file:////app/htsget_server/data/files/multisample_1.vcf.gz",
             "name": "multisample_1.vcf.gz"
@@ -40,18 +40,18 @@
         },
         "samples": [
             {
-                "genomic_file_sample_id": "TUMOR",
+                "analysis_sample_id": "TUMOR",
                 "submitter_sample_id": "SAMPLE_0002"
             },
             {
-              "genomic_file_sample_id": "NORMAL",
+              "analysis_sample_id": "NORMAL",
               "submitter_sample_id": "SAMPLE_0003"
             }
         ]
     },
     {
         "program_id": "SYNTH_02",
-        "genomic_file_id": "multisample_2",
+        "analysis_id": "multisample_2",
         "main": {
             "access_method": "file:////app/htsget_server/data/files/multisample_2.vcf.gz",
             "name": "multisample_2.vcf.gz"
@@ -67,18 +67,18 @@
         },
         "samples": [
             {
-                "genomic_file_sample_id": "TUMOR",
+                "analysis_sample_id": "TUMOR",
                 "submitter_sample_id": "SAMPLE_0020"
             },
             {
-                "genomic_file_sample_id": "NORMAL",
+                "analysis_sample_id": "NORMAL",
                 "submitter_sample_id": "SAMPLE_0019"
             }
         ]
     },
     {
         "program_id": "SYNTH_01",
-        "genomic_file_id": "NA02102",
+        "analysis_id": "NA02102",
         "main": {
             "access_method": "file:////app/htsget_server/data/files/NA02102.bam",
             "name": "NA02102.bam"
@@ -94,7 +94,7 @@
         },
         "samples": [
             {
-                "genomic_file_sample_id": "NA02102",
+                "analysis_sample_id": "NA02102",
                 "submitter_sample_id": "SAMPLE_0004"
             }
         ]

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -64,7 +64,7 @@ def test_htsget_ingest(requests_mock):
     # bad sample:
     bad_s3_sample = {
         "program_id": "SYNTHETIC-2",
-        "genomic_file_id": "bad_sample.cnv.vcf",
+        "analysis_id": "bad_sample.cnv.vcf",
         "main": {
             "access_method": "s3://1000genomes/release/20130502/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz?public=true",
             "name": "bad_sample.cnv.vcf.gz"
@@ -80,7 +80,7 @@ def test_htsget_ingest(requests_mock):
         },
         "samples": [
             {
-                "genomic_file_sample_id": "bad_sample",
+                "analysis_sample_id": "bad_sample",
                 "submitter_sample_id": "SAMPLE_REGISTRATION_1"
             }
         ]


### PR DESCRIPTION
LInes 47 and 74 are the only real changes: they shift the description of `wgs` (the library strategy) from the Analysis to the Experiment Drs Object and change the description of the Analysis to be `variant/read/transcript`. The rest of the changes are just renaming of variables to match the changes from GenomicDrsObject to AnalysisDrsObject and SampleDrsObject to ExperimentDrsObject.