### PR TITLE
Hotfix: check queue_id is a UUID

### DIFF
--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -236,8 +236,11 @@ def add_to_queue(ingest_json):
 
 @app.route('/status/<path:queue_id>')
 def get_ingest_status(queue_id):
+    uuid_match = re.match(r"^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$", queue_id)
+    if uuid_match is None:
+        return {"error": f"queue_id {queue_id} is not a UUID"}
     try:
-        results_path = os.path.join(config.DAEMON_PATH, "results", queue_id)
+        results_path = os.path.join(config.DAEMON_PATH, "results", uuid_match.group(0))
         with open(results_path) as f:
             json_data = json.load(f)
             # os.remove(results_path)

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-Flask==3.1.0
+Flask==3.1.1
 Flask-Cors==5.0.0
 connexion==3.1.0
 connexion[swagger-ui]


### PR DESCRIPTION
Snyk alerted me to this vulnerability: we should make sure that the user is not just passing an arbitrary string in as a UUID, since it does go into a path.

I also bumped Flask's version.