### PR TITLE
DIG-1974: Make sure roles are saved as lowercase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,7 @@ RUN chown -R candig:candig /ingest_app
 
 USER candig
 
+RUN touch initial_setup
+
 ENTRYPOINT ./entrypoint.sh
 EXPOSE 1235

--- a/auth.py
+++ b/auth.py
@@ -56,6 +56,9 @@ def add_program(program_auth):
     response, status_code = get_program(program_id)
     if status_code < 300 or status_code == 404:
         # create or update the program itself
+        program_auth["program_curators"] = list(map(lambda x: x.lower(), program_auth["program_curators"]))
+        program_auth["team_members"] = list(map(lambda x: x.lower(), program_auth["team_members"]))
+
         if "date_created" not in program_auth:
             from datetime import datetime
             program_auth["date_created"] = datetime.today().strftime('%Y-%m-%d')
@@ -133,6 +136,7 @@ def set_role_type(role_type, members):
     result, status_code = authx.auth.get_service_store_secret("opa", key=f"site_roles")
     if status_code == 200:
         if role_type in result['site_roles']:
+            members = list(map(lambda x: x.lower(), members))
             for user_id in members:
                 # if the user isn't already approved, make sure they will be:
                 response, status_code = add_preapproved_user(user_id)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
-mkdir -p $DAEMON_PATH/to_ingest
-mkdir -p $DAEMON_PATH/results
+
+if [[ -f "initial_setup" ]]; then
+    mkdir -p $DAEMON_PATH/to_ingest
+    mkdir -p $DAEMON_PATH/results
+    python migrate.py
+    rm initial_setup
+fi
+
 bash /ingest_app/daemon.sh &
 
 gunicorn -k uvicorn.workers.UvicornWorker server:app

--- a/migrate.py
+++ b/migrate.py
@@ -1,6 +1,10 @@
-import authx.auth
 import auth
 
+
+### Re-sets previously existing site roles and program roles:
+### they may have been saved with mixed-case names before DIG-1974
+### so will be re-saved by the updated set_role_type and add_program
+### to be all lower-case.
 
 def main():
     role_types, status_code = auth.list_role_types()

--- a/migrate.py
+++ b/migrate.py
@@ -1,0 +1,22 @@
+import authx.auth
+import auth
+
+
+def main():
+    role_types, status_code = auth.list_role_types()
+    if status_code == 200:
+        for role_type in role_types:
+            result, status_code = auth.get_role_type(role_type)
+            if status_code == 200:
+                auth.set_role_type(role_type, result[role_type])
+
+    programs, status_code = auth.list_programs()
+    if status_code == 200:
+        for program_id in programs:
+            program, status_code = auth.get_program(program_id)
+            if status_code == 200:
+                auth.add_program(program)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
When writing in programs and site roles, make sure that the user names are saved as lowercase only, since that is what Keycloak saves them as.

Also run a tiny migration script on initial setup (when re-composing this version of ingest) to update existing site roles and programs.