### PR TITLE
DIG-1966: better check for default site admin

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -8,11 +8,12 @@ import urllib
 
 
 def is_default_site_admin_set():
-    if os.getenv("DEFAULT_SITE_ADMIN_USER") is not None:
+    default_site_admin = os.getenv("DEFAULT_SITE_ADMIN_USER", "")
+    if default_site_admin != "":
         result, status_code = authx.auth.get_service_store_secret("opa", key=f"site_roles")
         if status_code == 200:
             if 'admin' in result['site_roles']:
-                return os.getenv("DEFAULT_SITE_ADMIN_USER") in ",".join(result['site_roles']['admin'])
+                return default_site_admin in ",".join(result['site_roles']['admin'])
         raise Exception(f"ERROR: Unable to list site administrators {result} {status_code}")
     return False
 


### PR DESCRIPTION
Make sure that the default site admin is neither present nor set to "".