### PR TITLE
Bump candig-logging version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests==2.32.4
 requests-mock>=1.12.1
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.7.3
 clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.2.0
-candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.3


### PR DESCRIPTION
Vulnerability found with Dependabot in candig-logging, so we've got to bump the version everywhere