### PR TITLE
DIG-2097: Ability to list DAC authorizations per program

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,14 @@
 if [[ -f "initial_setup" ]]; then
     mkdir -p $DAEMON_PATH/to_ingest
     mkdir -p $DAEMON_PATH/results
+    echo "Initializing setup"
     python migrate.py
-    rm initial_setup
+    if [[ $? -eq 0 ]]; then
+        rm initial_setup
+        echo "setup complete"
+    else
+        echo "!!!!!! INITIALIZATION FAILED, TRY AGAIN !!!!!!"
+    fi
 fi
 
 bash /ingest_app/daemon.sh &

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -189,6 +189,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Program"
+  /program/{program_id}/dac_authorization:
+    parameters:
+      - in: path
+        name: program_id
+        schema:
+          type: string
+        required: true
+    get:
+      summary: Get a program's DAC authorizations
+      description: Get a program's DAC authorizations
+      operationId: ingest_operations.get_program_dacs
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
   /user/pending/request:
     post:
       summary: Add pending user

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -160,7 +160,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Program"
+                  type: string
   /program/{program_id}:
     parameters:
       - in: path

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -594,6 +594,18 @@ async def add_dac_authz_for_user(user_id):
         except Exception as e:
             errors.append({program_id: f"Date format error: {type(e)} {str(e)}"})
         user_dict["dac_authorizations"][program_id] = program_dict
+
+        # add this dac to the program's authz
+        program, status_code = auth.get_program(program_id)
+        if status_code == 200:
+            if "dac_authorizations" not in program:
+                program["dac_authorizations"] = {}
+            program["dac_authorizations"][user_id] = program_dict
+            response, status_code = auth.add_program(program)
+            logger.debug(response, status_code)
+            if status_code != 200:
+                errors.append({program_id: response})
+
     if len(errors) == 0:
         user_dict, status_code = auth.write_user(user_dict)
         if "sample_jwt" in user_dict["userinfo"]:

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -576,23 +576,24 @@ async def add_dac_authz_for_user(user_id):
         return {"error": "Duplicate programs in request"}, 400
 
     for program_dict in program_body:
-        if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/user", program=program_dict["program_id"]):
-            errors.append({program_dict['program_id']: "User not authorized to authorize programs for user"})
+        program_id = program_dict.pop("program_id")
+        if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/user", program=program_id):
+            errors.append({program_id: "User not authorized to authorize programs for user"})
 
         # we need to check to see if the program even exists in the system
-        if program_dict["program_id"] not in all_programs:
-            errors.append({program_dict['program_id']: f"Program {program_dict['program_id']} does not exist in {all_programs}"})
+        if program_id not in all_programs:
+            errors.append({program_id: f"Program {program_id} does not exist in {all_programs}"})
 
         try:
             if datetime.fromisoformat(program_dict['end_date']) < datetime.fromisoformat(program_dict['start_date']):
-                errors.append({program_dict['program_id']: f"Start date {program_dict['start_date']} cannot be later than end date {program_dict['end_date']}"})
+                errors.append({program_id: f"Start date {program_dict['start_date']} cannot be later than end date {program_dict['end_date']}"})
             elif datetime.fromisoformat(program_dict['end_date']) == datetime.fromisoformat(program_dict['start_date']):
-                errors.append({program_dict['program_id']: f"Start date {program_dict['start_date']} is the same as end date {program_dict['end_date']}"})
+                errors.append({program_id: f"Start date {program_dict['start_date']} is the same as end date {program_dict['end_date']}"})
             elif datetime.fromisoformat(program_dict['end_date']) < datetime.now():
-                errors.append({program_dict['program_id']: f"Start date {program_dict['start_date']} and end date {program_dict['end_date']} are in the past"})
+                errors.append({program_id: f"Start date {program_dict['start_date']} and end date {program_dict['end_date']} are in the past"})
         except Exception as e:
-            errors.append({program_dict['program_id']: f"Date format error: {type(e)} {str(e)}"})
-        user_dict["dac_authorizations"][program_dict["program_id"]] = program_dict
+            errors.append({program_id: f"Date format error: {type(e)} {str(e)}"})
+        user_dict["dac_authorizations"][program_id] = program_dict
     if len(errors) == 0:
         user_dict, status_code = auth.write_user(user_dict)
         if "sample_jwt" in user_dict["userinfo"]:

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -286,7 +286,28 @@ def get_program(program_id):
         return {"error": f"User not authorized to get program {program_id}"}, 403
 
     response, status_code = auth.get_program(program_id)
+    if status_code == 200:
+        if "dac_authorizations" in response:
+            response.pop("dac_authorizations")
+
     return response, status_code
+
+
+@app.route('/program/<path:program_id>/dac_authorization')
+def get_program_dacs(program_id):
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/program", program=program_id):
+        return {"error": f"User not authorized to get program {program_id}"}, 403
+
+    response, status_code = auth.get_program(program_id)
+    dac_authz = {}
+
+    if status_code == 200:
+        if "dac_authorizations" in response:
+            dac_authz = response.pop("dac_authorizations")
+
+    return dac_authz, status_code
 
 
 @app.route('/program/<path:program_id>')

--- a/ingest_operations.py
+++ b/ingest_operations.py
@@ -576,7 +576,7 @@ async def add_dac_authz_for_user(user_id):
         return {"error": "Duplicate programs in request"}, 400
 
     for program_dict in program_body:
-        program_id = program_dict.pop("program_id")
+        program_id = program_dict["program_id"]
         if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/user", program=program_id):
             errors.append({program_id: "User not authorized to authorize programs for user"})
 

--- a/migrate.py
+++ b/migrate.py
@@ -1,10 +1,21 @@
 import auth
+import sys
+import os
+import authx.auth
+import requests
 
 
 ### Re-sets previously existing site roles and program roles:
 ### they may have been saved with mixed-case names before DIG-1974
 ### so will be re-saved by the updated set_role_type and add_program
 ### to be all lower-case.
+
+### DIG-2097: Go through all programs and users to update their
+### dac_authorizations.
+
+VAULT_URL = os.getenv("VAULT_URL")
+SERVICE_NAME = os.getenv("SERVICE_NAME")
+
 
 def main():
     role_types, status_code = auth.list_role_types()
@@ -15,11 +26,58 @@ def main():
                 auth.set_role_type(role_type, result[role_type])
 
     programs, status_code = auth.list_programs()
-    if status_code == 200:
-        for program_id in programs:
-            program, status_code = auth.get_program(program_id)
-            if status_code == 200:
-                auth.add_program(program)
+    print(programs)
+    if status_code != 200:
+        print(f"Couldn't list programs: {programs} {status_code}")
+        sys.exit(1)
+
+    # start a dictionary of programs that we can then add dacs to
+    programs_dict = {}
+    for program_id in programs:
+        program, status_code = auth.get_program(program_id)
+        if status_code == 200:
+            programs_dict[program_id] = program
+            programs_dict[program_id]["dac_authorizations"] = {}
+
+    # need to call Vault to get the list of users
+    headers = {
+        "X-Vault-Token": authx.auth.get_vault_token_for_service()
+    }
+    url = f"{VAULT_URL}/v1/opa/users"
+    response = requests.request("LIST", url, headers=headers)
+    if response.status_code != 200:
+        print(f"Couldn't list users: {response.text} {response.status_code}")
+        sys.exit(1)
+
+    result = response.json()["data"]["keys"]
+    for user_id in result:
+        user_dict, status_code = auth.get_user(user_id)
+        if status_code != 200:
+            print(f"Couldn't get user {user_id}: {user_dict} {status_code}")
+            sys.exit(1)
+
+        if "dac_authorizations" in user_dict:
+            for program_id in user_dict["dac_authorizations"]:
+                # remove the program_id key from the user's dac_authorization
+                if "program_id" in user_dict["dac_authorizations"][program_id]:
+                    user_dict["dac_authorizations"][program_id].pop("program_id")
+
+                # add the user's dac authz to the program
+                programs_dict[program_id]["dac_authorizations"][user_id] = user_dict["dac_authorizations"][program_id]
+
+        # write the user back
+        response, status_code = auth.write_user(user_dict)
+        if status_code != 200:
+            print(f"Couldn't write user {user_id}: {response} {status_code}")
+            sys.exit(1)
+        # print(response)
+
+    for program_id in programs_dict:
+        response, status_code = auth.add_program(programs_dict[program_id])
+        if status_code != 200:
+            print(f"Couldn't write program {program_id}: {response} {status_code}")
+            sys.exit(1)
+        # print(response)
 
 
 if __name__ == "__main__":

--- a/migrate.py
+++ b/migrate.py
@@ -49,12 +49,12 @@ def main():
         print(f"Couldn't list users: {response.text} {response.status_code}")
         sys.exit(1)
 
+    errors = []
     result = response.json()["data"]["keys"]
     for user_id in result:
         user_dict, status_code = auth.get_user(user_id)
         if status_code != 200:
-            print(f"Couldn't get user {user_id}: {user_dict} {status_code}")
-            sys.exit(1)
+            errors.append(f"Couldn't get user {user_id}: {user_dict} {status_code}")
 
         if "dac_authorizations" in user_dict:
             for program_id in user_dict["dac_authorizations"]:
@@ -64,17 +64,18 @@ def main():
         # write the user back
         response, status_code = auth.write_user(user_dict)
         if status_code != 200:
-            print(f"Couldn't write user {user_id}: {response} {status_code}")
-            sys.exit(1)
+            errors.append(f"Couldn't write user {user_id}: {response} {status_code}")
         # print(response)
 
     for program_id in programs_dict:
         response, status_code = auth.add_program(programs_dict[program_id])
         if status_code != 200:
-            print(f"Couldn't write program {program_id}: {response} {status_code}")
-            sys.exit(1)
+            errors.append(f"Couldn't write program {program_id}: {response} {status_code}")
         # print(response)
 
+    if len(errors) > 0:
+        print(errors)
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/migrate.py
+++ b/migrate.py
@@ -58,10 +58,6 @@ def main():
 
         if "dac_authorizations" in user_dict:
             for program_id in user_dict["dac_authorizations"]:
-                # remove the program_id key from the user's dac_authorization
-                if "program_id" in user_dict["dac_authorizations"][program_id]:
-                    user_dict["dac_authorizations"][program_id].pop("program_id")
-
                 # add the user's dac authz to the program
                 programs_dict[program_id]["dac_authorizations"][user_id] = user_dict["dac_authorizations"][program_id]
 


### PR DESCRIPTION
In order to list the DAC authz for each program, we have to do two things:

1. for new DAC authz, we need to write it into both the user's vault secret as well as the program's vault secret.
2. for already-ingested programs and users, we need to migrate: for all existing users, find all of their dac auths and write those into the corresponding programs' vault secrets.

In order to run this migration, make sure you're testing this from the [CanDIGv2 branch](https://github.com/CanDIG/CanDIGv2/pull/1175), because there are necessary vault setup changes. Run `make compose-vault` before running `make recompose-candig-ingest`.