### PR TITLE
DIG-2080: add analysis_date, if provided

### DIFF
--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -223,12 +223,17 @@ def link_genomic_data(analysis, do_not_index=False):
             result["errors"].append(f"could not verify analysis: {response.text}")
             return result
         elif not response.json()['result']:
-            result["errors"].append(f"could not verify analysis: {response.json()['message']}")
-            return result
-        else:
-            # flag the analysis_drs_object for indexing:
-            url =f"{HTSGET_URL}/htsget/v1/{analysis_drs_obj['id']}/index"
-            result["to_index"] = [url]
+            # was an analysis_date specified? if so, it's not an error if the verification fails because it doesn't have one
+            if 'does not have any associated analysis date' in response.json()['message']:
+                if 'analysis_date' not in analysis_drs_obj['metadata']:
+                    result["errors"].append(f"could not verify analysis: {response.text}")
+                    return result
+            else:
+                result["errors"].append(f"could not verify analysis: {response.json()['message']}")
+                return result
+        # flag the analysis_drs_object for indexing:
+        url =f"{HTSGET_URL}/htsget/v1/{analysis_drs_obj['id']}/index"
+        result["to_index"] = [url]
     return result
 
 

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -898,6 +898,9 @@ components:
                 - reference_alignment
                 - sequence_variation
                 - sequence_annotation
+            analysis_date:
+              type: string
+              description: date analysis was performed. If not specified, it will be taken either from the fileDate header or derived from another date-containing header.
             analysis_attribute:
               type: object
               properties:

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -902,7 +902,7 @@ components:
               type: string
               format: date
               example: "2024-01-24"
-              description: date analysis was performed. If not specified, it will be taken either from the fileDate header or derived from another date-containing header.
+              description: date analysis was performed in the format YYYY-MM-DD. If not specified, it will be taken either from the fileDate header or derived from another date-containing header. 
             analysis_attribute:
               type: object
               properties:

--- a/ingest_openapi.yaml
+++ b/ingest_openapi.yaml
@@ -900,6 +900,8 @@ components:
                 - sequence_annotation
             analysis_date:
               type: string
+              format: date
+              example: "2024-01-24"
               description: date analysis was performed. If not specified, it will be taken either from the fileDate header or derived from another date-containing header.
             analysis_attribute:
               type: object


### PR DESCRIPTION
On genomic ingest, the htsget verification will look for a date in the vcf headers. If there is no date specified in the vcf file AND no date specified in the genomic ingest file, the analysis won't be ingested.

Testing in https://github.com/CanDIG/CanDIGv2/pull/1240