### PR TITLE
DIG-2296: don't ingest analyses that refer to experiments not in the same program

### DIFF
--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -513,9 +513,9 @@ def htsget_ingest(ingest_json, overwrite=False, results_path=None, result_dict=N
                     if "403" in err:
                         status_code = 403
                         break
-                    result["results"].append(f"error processing {response["id"]} {response["name"]} in experiment {run["experiment_id"]}: {err}")
+                    result["results"].append(f"error processing {response["id"]} {response["name"]} in run {run["run_id"]}: {err}")
             else:
-                result["results"].append(f"processed {response["id"]} {response["name"]} for experiment {run["experiment_id"]}")
+                result["results"].append(f"processed {response["id"]} {response["name"]} for run {run["run_id"]}")
                 if "sample" in response:
                     result["results"].append(response["sample"])
 
@@ -552,9 +552,9 @@ def htsget_ingest(ingest_json, overwrite=False, results_path=None, result_dict=N
                 if "403" in err:
                     status_code = 403
                     break
-                result["results"].append(f"error processing {response["id"]} {response["name"]} in experiment {analysis["analysis_id"]}: {err}")
+                result["results"].append(f"error processing {response["id"]} {response["name"]} in analysis {analysis["analysis_id"]}: {err}")
         else:
-            result["results"].append(f"processed {response["id"]} {response["name"]} for experiment {analysis["analysis_id"]}")
+            result["results"].append(f"processed {response["id"]} {response["name"]} for analysis {analysis["analysis_id"]}")
             if "sample" in response:
                 result["results"].append(response["sample"])
             result["summary"]["analyses"]["ingested"] += 1

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -81,6 +81,9 @@ def create_analysis(analysis, overwrite=False):
         response = requests.get(f"{url}/{clin_sample['experiment_id']}", headers=headers)
         if response.status_code == 200:
             experiment_drs_obj = response.json()
+            if experiment_drs_obj["program"] != analysis["program_id"]:
+                result["errors"].append(f"matching experiment drs object {clin_sample['experiment_id']} is not in program {analysis["program_id"]}")
+                return result
         else:
             result["errors"].append(f"couldn't find experiment drs object {clin_sample['experiment_id']}: {response.status_code} {response.text}")
             return result

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -36,7 +36,7 @@ def verify_callback(request, context):
 def test_htsget_ingest(requests_mock):
     matcher = re.compile(f"{DRS_URL}/ga4gh/drs/v1/objects/.+")
     requests_mock.post(f"{DRS_URL}/ga4gh/drs/v1/objects", json=callback, status_code=200)
-    requests_mock.get(matcher, status_code=200, json={"id": "sdfs", "name": "sfdfs", "contents": []})
+    requests_mock.get(matcher, status_code=200, json={"id": "sdfs", "name": "sfdfs", "contents": [], "program": "LOCAL-SYNTH_01"})
     matcher = re.compile(f"{HTSGET_URL}/htsget/v1/.+/index")
     requests_mock.get(matcher, status_code=200)
     matcher = re.compile(f"{HTSGET_URL}/htsget/v1/.+/verify")
@@ -65,9 +65,14 @@ def test_htsget_ingest(requests_mock):
         for sample in data["analyses"]:
             response = htsget_ingest.create_analysis(sample, overwrite=True)
             print(json.dumps(response, indent=4))
-            assert len(response["errors"]) == 0
-            assert "name" in response
-            assert "sample" in response
+            if sample["program_id"] == "LOCAL-SYNTH_02":
+                # there will be a mismatch error for the program: "...is not in program LOCAL-SYNTH_02"
+                assert len(response["errors"]) == 1
+                assert "is not in program LOCAL-SYNTH_02" in str(response["errors"])
+            else:
+                assert len(response["errors"]) == 0
+                assert "name" in response
+                assert "sample" in response
 
     # bad sample:
     bad_s3_sample = {


### PR DESCRIPTION
If an experiment ID in your genomic json is accidentally a duplicate of an existing experiment ID in another program, you could end up in a situation where the analysis you are trying to link to the program will be created with a link to a different program's experiment. This is not what we expect!

To test this, after recomposing your candig-ingest, download [small_dataset_genomic_ingest.json](https://github.com/user-attachments/files/26722509/small_dataset_genomic_ingest.json) and 
[LOCAL-SYNTH_02.json](https://github.com/user-attachments/files/26722658/LOCAL-SYNTH_02.json)
 and do the following:
```
curl -X "DELETE" "http://candig.docker.internal:5080/ingest/program/local-SYNTH_02" \
     -H "Authorization: Bearer $SITE_ADMIN_TOKEN"
curl -X "POST" "http://candig.docker.internal:5080/ingest/program" \
     -H "Authorization: Bearer $SITE_ADMIN_TOKEN"
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "team_members": [],
  "program_curators": [],
  "program_id": "local-SYNTH_02"
}'
curl -X "POST" "http://candig.docker.internal:5080/ingest/ingest" \
     -H "Authorization: Bearer $SITE_ADMIN_TOKEN"
     -H 'Content-Type: application/json' \
     -d @LOCAL-SYNTH_02.json
curl -X "POST" "http://candig.docker.internal:5080/ingest/ingest" \
     -H "Authorization: Bearer $SITE_ADMIN_TOKEN"
     -H 'Content-Type: application/json' \
     -d @small_dataset_genomic_ingest.json
```
The status result from the last ingest should contain the following:
```
"error processing analysis test.vcf.gz in analysis local-test2: matching experiment drs object local-SEQ_0002 is not in program local-SYNTH_02"
```


