### PR TITLE
DIG-2280: check daemon to see if it's still responding

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -33,6 +33,8 @@ def ingest_file(file_path):
                 json_data = json_data["katsu"]
                 programs = list(json_data.keys())
                 for program_id in programs:
+                    with open(f"{DAEMON_PATH}/last_touch.txt", "w") as f:
+                        f.write(str(int(datetime.now().timestamp())))
                     try:
                         ingest_results, status_code = ingest_schemas(json_data[program_id]["schemas"], results_path=results_path, result_dict=results, program_id=program_id)
                         results[program_id] = ingest_results
@@ -47,6 +49,8 @@ def ingest_file(file_path):
                 for program_id in programs:
                     results[program_id] = {}
                 for program_id in programs:
+                    with open(f"{DAEMON_PATH}/last_touch.txt", "w") as f:
+                        f.write(str(int(datetime.now().timestamp())))
                     try:
                         ingest_results, status_code = htsget_ingest(json_data[program_id], overwrite=overwrite, results_path=results_path, result_dict=results)
                         results[program_id] = ingest_results
@@ -72,7 +76,10 @@ def ingest_file(file_path):
 
 class DaemonHandler(watchdog.events.FileSystemEventHandler):
     def on_created(self, event):
+        with open(f"{DAEMON_PATH}/last_touch.txt", "w") as f:
+            f.write(str(int(datetime.now().timestamp())))
         ingest_file(event.src_path)
+        os.remove(f"{DAEMON_PATH}/last_touch.txt")
 
 
 if __name__ == "__main__":

--- a/daemon.sh
+++ b/daemon.sh
@@ -33,6 +33,7 @@ do
         echo "Restarting daemon"
         if [[ -f $TOUCH_FILE ]]; then
             rm $TOUCH_FILE
+        fi
         python daemon.py &
         pid=$!
     fi

--- a/daemon.sh
+++ b/daemon.sh
@@ -1,4 +1,21 @@
-until python daemon.py; do
-    echo "Daemon crashed with exit code $?.  Respawning.." >&2
-    sleep 1
+#!/bin/bash
+
+python daemon.py &
+pid=$!
+
+while true
+do
+    sleep 60
+    restart_me=0 # if this is 1, respawn daemon and resave pid
+
+    if [[ $(ps -p $pid | wc -l) == 1 ]]; then
+        echo "Process $pid has terminated"
+        restart_me=1
+    fi
+
+    if [[ $restart_me == 1 ]]; then
+        echo "Restarting daemon"
+        python daemon.py &
+        pid=$!
+    fi
 done

--- a/daemon.sh
+++ b/daemon.sh
@@ -12,25 +12,27 @@ do
     sleep 60
     restart_me=0 # if this is 1, respawn daemon and resave pid
 
-    # check to see if the touch file exists and is still updating
-    if [[ -f $TOUCH_FILE ]]; then
-        now=$(date +%s)
-        last_touch=$(cat $TOUCH_FILE)
-        echo "Ingest in process...last updated" $(($now - $last_touch)) "seconds ago"
-        if [[ $(($now - $last_touch)) > $(($interval)) ]]; then
-            echo "Last update was more than" $interval "seconds ago"
-            rm $TOUCH_FILE
-            restart_me=1
-        fi
-    fi
-
     if [[ $(ps -p $pid | wc -l) == 1 ]]; then
         echo "Process $pid has terminated"
         restart_me=1
     fi
 
+    # check to see if the touch file exists and is still updating
+    if [[ -f $TOUCH_FILE ]]; then
+        now=$(date +%s)
+        last_touch=$(cat $TOUCH_FILE)
+        echo "Ingest in process...last updated" $(($now - $last_touch)) "seconds ago"
+        if (($now - $last_touch > $interval)); then
+            echo "Last update was more than" $interval "seconds ago"
+            kill $pid
+            restart_me=1
+        fi
+    fi
+
     if [[ $restart_me == 1 ]]; then
         echo "Restarting daemon"
+        if [[ -f $TOUCH_FILE ]]; then
+            rm $TOUCH_FILE
         python daemon.py &
         pid=$!
     fi

--- a/daemon.sh
+++ b/daemon.sh
@@ -1,12 +1,28 @@
 #!/bin/bash
 
+TOUCH_FILE=$DAEMON_PATH/last_touch.txt
+
 python daemon.py &
 pid=$!
+
+interval=$((30*60)) # the length of time to wait for updates in TOUCH_FILE
 
 while true
 do
     sleep 60
     restart_me=0 # if this is 1, respawn daemon and resave pid
+
+    # check to see if the touch file exists and is still updating
+    if [[ -f $TOUCH_FILE ]]; then
+        now=$(date +%s)
+        last_touch=$(cat $TOUCH_FILE)
+        echo "Ingest in process...last updated" $(($now - $last_touch)) "seconds ago"
+        if [[ $(($now - $last_touch)) > $(($interval)) ]]; then
+            echo "Last update was more than" $interval "seconds ago"
+            rm $TOUCH_FILE
+            restart_me=1
+        fi
+    fi
 
     if [[ $(ps -p $pid | wc -l) == 1 ]]; then
         echo "Process $pid has terminated"


### PR DESCRIPTION
I rewrote the bash daemon script to check two things:
* use the pid of the spawned python daemon to check to see if it's still running
* check to see if a last_touch file exists, and if so, if it's been updated more recently than 30 minutes ago

If either condition is not met, then restart the python daemon.

To test:
* try using top and finding the python job (probably the newest one). Kill that job. Then watch the log: within a minute, the log should show "Restarting daemon" and a restart of that process.
* run `echo 1776790259 > /home/candig/tmp/last_touch.txt` inside the container. Then watch the log: within a minute, the log should show "Last update was more than 1800 seconds ago" and then a restart of the process.