### PR TITLE
DIG-2282: Include verification flag on ingest

### DIFF
--- a/helper_scripts/extract_drs.py
+++ b/helper_scripts/extract_drs.py
@@ -4,8 +4,8 @@ import requests
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Extract all drs objects associated with the experiments endpoint result.")
-    parser.add_argument('--file', type=str, required=True, help="File with output of experiments call")
+    parser = argparse.ArgumentParser(description="Extract all drs objects associated with the biosamples endpoint result.")
+    parser.add_argument('--file', type=str, required=True, help="File with output of biosamples call")
     parser.add_argument('--url', type=str, required=True, help="URL of the candig deployment you are retrieving data from")
     parser.add_argument('--token', type=str, required=True, help="site admin token for the candig deployment you are retrieving data from.")
     parser.add_argument('--output', type=str, required=True, help="output file to write to")
@@ -18,15 +18,15 @@ def main():
     args = parse_args()
 
     with open(args.file, "r") as f:
-        experiments = json.load(f)
+        biosamples = json.load(f)
 
     experiment_drs_objects = {}
-    for exp in experiments:
+    for sample in biosamples:
         # collect all of the ExperimentDrsObjects
-        if len(exp["genomes"]) > 0:
-            experiment_drs_objects[exp["experiment_id"]] = exp["genomes"]
-        if len(exp["transcriptomes"]) > 0:
-            experiment_drs_objects[exp["experiment_id"]] = exp["transcriptomes"]
+        if len(sample["experiments"]["wgs"]) > 0:
+            experiment_drs_objects[sample["biosample_id"]] = sample["experiments"]["wgs"]
+        if len(sample["experiments"]["wts"]) > 0:
+            experiment_drs_objects[sample["biosample_id"]] = sample["experiments"]["wts"]
 
     print("Gathered all experiment drs objects")
     result = {}

--- a/helper_scripts/extract_drs.py
+++ b/helper_scripts/extract_drs.py
@@ -5,7 +5,7 @@ import requests
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Extract all drs objects associated with the biosamples endpoint result.")
-    parser.add_argument('--file', type=str, required=True, help="File with output of biosamples call")
+    parser.add_argument('--file', type=str, required=False, help="File with output of biosamples call")
     parser.add_argument('--url', type=str, required=True, help="URL of the candig deployment you are retrieving data from")
     parser.add_argument('--token', type=str, required=True, help="site admin token for the candig deployment you are retrieving data from.")
     parser.add_argument('--output', type=str, required=True, help="output file to write to")
@@ -17,8 +17,19 @@ def parse_args():
 def main():
     args = parse_args()
 
-    with open(args.file, "r") as f:
-        biosamples = json.load(f)
+    headers = {"Authorization": f"Bearer {args.token}",
+       "Content-Type": "application/json; charset=utf-8"}
+
+    if args.file is not None:
+        with open(args.file, "r") as f:
+            biosamples = json.load(f)
+    else:
+        response = requests.post(f"{args.url}/drs/ga4gh/drs/v1/biosamples", headers=headers, json={})
+        if response.status_code == 200:
+            biosamples = response.json()
+        else:
+            print(f"Couldn't get a list of biosamples: {response.status_code} {response.text}")
+            return
 
     experiment_drs_objects = {}
     for sample in biosamples:
@@ -31,8 +42,6 @@ def main():
     print("Gathered all experiment drs objects")
     result = {}
     errors = []
-    headers = {"Authorization": f"Bearer {args.token}",
-       "Content-Type": "application/json; charset=utf-8"}
     contents_types = ["analysis", "variant", "read", "transcript", "index"]
 
     while len(experiment_drs_objects) > 0:

--- a/helper_scripts/verified_analyses.py
+++ b/helper_scripts/verified_analyses.py
@@ -1,0 +1,57 @@
+import json
+import argparse
+import requests
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Get verified status of all analyses associated with the biosamples endpoint result.")
+    parser.add_argument('--file', type=str, required=False, help="File with output of biosamples call")
+    parser.add_argument('--url', type=str, required=True, help="URL of the candig deployment you are retrieving data from")
+    parser.add_argument('--token', type=str, required=True, help="site admin token for the candig deployment you are retrieving data from.")
+    parser.add_argument('--output', type=str, required=True, help="output file to write to")
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+
+    headers = {"Authorization": f"Bearer {args.token}",
+       "Content-Type": "application/json; charset=utf-8"}
+
+    if args.file is not None:
+        with open(args.file, "r") as f:
+            biosamples = json.load(f)
+    else:
+        response = requests.post(f"{args.url}/drs/ga4gh/drs/v1/biosamples", headers=headers, json={})
+        if response.status_code == 200:
+            biosamples = response.json()
+        else:
+            print(f"Couldn't get a list of biosamples: {response.status_code} {response.text}")
+            return
+
+    result = []
+    errors = []
+    analyses = set()
+    for sample in biosamples:
+        if "analyses" in sample and len(sample["analyses"]) > 0:
+            for type in sample["analyses"]:
+                analyses.update(sample["analyses"][type])
+
+    for analysis in analyses:
+        response = requests.get(f"{args.url}/drs/ga4gh/drs/v1/objects/{analysis}", headers=headers)
+        if response.status_code == 401:
+            # token is unauthorized/expired
+            print(response.text)
+            return
+        if response.status_code == 200:
+            result.append(f"{analysis}, {response.json()["metadata"]["last_verified"]}")
+
+
+    with open(args.output, "w") as f:
+        for line in result:
+            f.write(f"{line}\n")
+
+if __name__ == "__main__":
+    main()

--- a/helper_scripts/verified_analyses.py
+++ b/helper_scripts/verified_analyses.py
@@ -32,7 +32,6 @@ def main():
             return
 
     result = []
-    errors = []
     analyses = set()
     for sample in biosamples:
         if "analyses" in sample and len(sample["analyses"]) > 0:

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -57,7 +57,7 @@ def create_analysis(analysis, overwrite=False):
     analysis_drs_obj["reference_genome"] = analysis["metadata"]["reference"]
     analysis_drs_obj["version"] = "v1"
     analysis_drs_obj["metadata"] = analysis["metadata"]
-    analysis_drs_obj["metadata"]["verified"] = 0
+    analysis_drs_obj["metadata"]["last_verified"] = ""
     if "contents" not in analysis_drs_obj:
         analysis_drs_obj["contents"] = []
 
@@ -159,7 +159,7 @@ def create_analysis(analysis, overwrite=False):
                 # ingest matrix
                 response = requests.get(f"{DRS_URL}/ga4gh/drs/v1/objects/{analysis["main"]["name"]}/download", headers=headers)
                 if response.status_code == 200:
-                    analysis_drs_obj['metadata']['verified'] = 1
+                    analysis_drs_obj['metadata']['last_verified'] = str(datetime.now())
                     raw_tsv_data = response.text.strip()
                     lines = raw_tsv_data.split("\n")
                     titles = lines.pop(0).split("\t")
@@ -250,7 +250,7 @@ def create_analysis(analysis, overwrite=False):
             else:
                 result["errors"].append(f"could not verify analysis: {response.json()['message']}")
                 return result
-        analysis_drs_obj['metadata']['verified'] = 1
+        analysis_drs_obj['metadata']['last_verified'] = str(datetime.now())
 
         # flag the analysis_drs_object for indexing:
         index_url =f"{HTSGET_URL}/htsget/v1/{analysis_drs_obj['id']}/index"

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -114,7 +114,7 @@ def create_analysis(analysis, overwrite=False):
         not_found = True
         if len(analysis_drs_obj["contents"]) > 0:
             for i in range(0, len(analysis_drs_obj["contents"])):
-                if analysis_drs_obj["contents"][i]["name"] == clin_sample["experiment_id"]:
+                if analysis_drs_obj["contents"][i]["name"] == experiment_drs_obj["name"]:
                     not_found = False
                     analysis_drs_obj["contents"][i] = contents_obj
                     break

--- a/htsget_ingest.py
+++ b/htsget_ingest.py
@@ -57,6 +57,7 @@ def create_analysis(analysis, overwrite=False):
     analysis_drs_obj["reference_genome"] = analysis["metadata"]["reference"]
     analysis_drs_obj["version"] = "v1"
     analysis_drs_obj["metadata"] = analysis["metadata"]
+    analysis_drs_obj["metadata"]["verified"] = 0
     if "contents" not in analysis_drs_obj:
         analysis_drs_obj["contents"] = []
 
@@ -135,7 +136,8 @@ def create_analysis(analysis, overwrite=False):
             response = requests.post(f"{TAKUAN_URL}/experiment/{experiment_drs_obj["id"]}/features", headers=headers)
             if response.status_code == 200:
                 logger.info(f"experiment {experiment_drs_obj["id"]} already ingested")
-                return result
+                if not overwrite:
+                    return result
         except Exception as e:
             logger.info(f"exception looking up {TAKUAN_URL}/experiment/{experiment_drs_obj["id"]}/features: {type(e)} {str(e)}")
 
@@ -157,6 +159,7 @@ def create_analysis(analysis, overwrite=False):
                 # ingest matrix
                 response = requests.get(f"{DRS_URL}/ga4gh/drs/v1/objects/{analysis["main"]["name"]}/download", headers=headers)
                 if response.status_code == 200:
+                    analysis_drs_obj['metadata']['verified'] = 1
                     raw_tsv_data = response.text.strip()
                     lines = raw_tsv_data.split("\n")
                     titles = lines.pop(0).split("\t")
@@ -247,9 +250,18 @@ def create_analysis(analysis, overwrite=False):
             else:
                 result["errors"].append(f"could not verify analysis: {response.json()['message']}")
                 return result
+        analysis_drs_obj['metadata']['verified'] = 1
+
         # flag the analysis_drs_object for indexing:
-        url =f"{HTSGET_URL}/htsget/v1/{analysis_drs_obj['id']}/index"
-        result["to_index"] = [url]
+        index_url =f"{HTSGET_URL}/htsget/v1/{analysis_drs_obj['id']}/index"
+        result["to_index"] = [index_url]
+
+    # update the analysis_drs_object
+    response = requests.post(url, json=analysis_drs_obj, headers=headers)
+    if response.status_code != 200:
+        result["errors"].append(f"error posting analysis drs object {analysis_drs_obj['id']}: {response.status_code} {response.text}")
+        return result
+
     return result
 
 


### PR DESCRIPTION
During ingest, files that are associated with analyses are verified to be readable; if they are, add a `last_verified` timestamp to the analysis metadata.

Added a helper script that will find all of the analyses in the system and their last_verified timestamps.

Updated the extract_drs helper script to use the current `biosamples` endpoint instead of the old `experiments` endpoint that is being deprecated.

Fixed a bug in which the wrong field was being checked for duplication when adding contents to analysis drs objects.