### PR TITLE
Bump clinical_ETL_code version to accept Not available in clinically minimal required fields.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.32.4
 requests-mock>=1.12.1
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.7
-clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.2.0
+clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.4.0
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.3


### PR DESCRIPTION
As per the discussion [in this Slack post](https://candig.slack.com/archives/C02TJS4J96U/p1768267187023929).
It looks like it just never made it into the stable branch.