### PR TITLE
DIG-2362: adding index_unindexed script and description

### DIFF
--- a/helper_scripts/index_unindexed.sh
+++ b/helper_scripts/index_unindexed.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -Euo pipefail
+
+postgres=$(docker ps --format "{{.Names}}" | grep postgres-db | awk '{print $1}')
+
+length=$(docker exec $postgres sh -c "psql -U admin -d drs -c \"copy (select id from drs_object where description = 'sequence_variation' and meta_data ? 'index_status') To '/tmp/unindexed.csv';\"" | awk '{print $NF}')
+
+if [ $length -gt 0 ]; then
+    myfile=$(mktemp --suffix ".csv")
+    copy=$(docker cp $postgres:/tmp/unindexed.csv $myfile)
+    remove=$(docker exec $postgres rm /tmp/unindexed.csv)
+    echo "# $length variant files to index"
+    echo "# Set the env vars \$TOKEN and \$CANDIG_URL before running the following curl commands."
+    for id in $(cat $myfile)
+    do
+        echo curl "\"\$CANDIG_URL/genomics/htsget/v1/$id/index?force=true\" -H \"Content-Type: application/json\" -H \"Authorization: Bearer \$TOKEN\""
+    done
+    rm $myfile
+else
+    echo "# No unindexed entries were found"
+fi

--- a/helper_scripts/readme.md
+++ b/helper_scripts/readme.md
@@ -25,4 +25,7 @@ program registrations that do not already exist.
 
 `index_unindexed.sh`
 
-Searches the database for variant files that are not fully indexed and creates a list of curl commands to index them again. Pipe the output of this script to a file and run the curl commands in batches if there are too many to do at once.
+Searches the database for variant files that are not fully indexed and creates a list of curl commands to index them again. Pipe the output of this script to a file and run the curl commands in batches if there are too many to do at once. 
+
+> [!IMPORTANT]
+> This script needs to be run on the VM where your CanDIG node is deployed as it needs direct access to the postgres docker container.

--- a/helper_scripts/readme.md
+++ b/helper_scripts/readme.md
@@ -1,24 +1,28 @@
 # Ingest helper scripts
 
-A collection of scripts for performing various data summary and update actions. Some of these may be directly useful, others are provided as examples based on a specific use case. 
+A collection of scripts for performing various data summary and update actions. Some of these may be directly useful, others are provided as examples based on a specific use case.
 
 `delete_clinical_data_katsu.py`
 
 Delete only clinical data from all/specified programs at a node.
 
-`extract_drs.py` 
+`extract_drs.py`
 
-Given the output from a call to the `experiments` endpoint, collect all of the drs objects for those experiments. Written to go alongside the `reset_programs.py` script. 
+Given the output from a call to the `experiments` endpoint, collect all of the drs objects for those experiments. Written to go alongside the `reset_programs.py` script.
 
 `reset_programs.py`
 
-A CanDIG instance renamed the program_id and updated clinical data. This script (along with `extract_drs`) updated the program_ids in the sequencing metadata without having to re-ingest all of the sequencing data. 
+A CanDIG instance renamed the program_id and updated clinical data. This script (along with `extract_drs`) updated the program_ids in the sequencing metadata without having to re-ingest all of the sequencing data.
 
 `get_ingested_files.py`
 
-Returns a list of ingested sequencing files for the CanDIG instance. 
+Returns a list of ingested sequencing files for the CanDIG instance.
 
 `submit_program_registrations.py`
 
-Submits all program registrations in a csv file, adding team members and program curators as specified. Only adds 
+Submits all program registrations in a csv file, adding team members and program curators as specified. Only adds
 program registrations that do not already exist.
+
+`index_unindexed.sh`
+
+Searches the database for variant files that are not fully indexed and creates a list of curl commands to index them again. Pipe the output of this script to a file and run the curl commands in batches if there are too many to do at once.


### PR DESCRIPTION
Since this is just a shell script, you can either check this branch out in your local and run it directly without rebuilding anything.

I'd recommend running this script on a production server; it's hard to test it in an environment where there aren't any unindexed files. Again, just check out the branch but don't rebuild/recompose anything: `bash index_unindexed.sh > unindexed.txt` should do it.
